### PR TITLE
CA-112409: Set default parameter set for the constructor cmdlets or Get-...

### DIFF
--- a/powershell/gen_powershell_binding.ml
+++ b/powershell/gen_powershell_binding.ml
@@ -468,7 +468,7 @@ using XenAPI;
 
 namespace Citrix.XenServer.Commands
 {
-    [Cmdlet(VerbsCommon.New, \"Xen%s\", SupportsShouldProcess = true)]
+    [Cmdlet(VerbsCommon.New, \"Xen%s\", DefaultParameterSetName = \"Hashtable\", SupportsShouldProcess = true)]
     [OutputType(typeof(%s))]%s
     [OutputType(typeof(void))]
     public class NewXen%sCommand : XenServerCmdlet


### PR DESCRIPTION
...Command

is not working in PowerShell v2.0.

Signed-off-by: Konstantina Chremmou konstantina.chremmou@citrix.com
