### PR TITLE
CP-5500: Removed module manifest parameters that were introduced in PowerShell 3.0.

### DIFF
--- a/powershell/XenServerPSModule.psd1
+++ b/powershell/XenServerPSModule.psd1
@@ -72,14 +72,11 @@ FileList = @('about_XenServer.help.txt',
              'XenServerPowerShell.dll')
 
 #Public interface
-DefaultCommandPrefix = ''
 FunctionsToExport = ''
 CmdletsToExport = '*'
 VariablesToExport = @('Citrix.XenServer.Sessions','XenServer_Default_Session')
 AliasesToExport = '*'
 
 PrivateData = ''
-
-HelpInfoURI = ''
 
 }


### PR DESCRIPTION
Signed-off-by: Konstantina Chremmou konstantina.chremmou@citrix.com
