### PR TITLE
Client side connection timeout and a check for if an object is null.

### DIFF
--- a/java/lib/com/xensource/xenapi/Connection.java
+++ b/java/lib/com/xensource/xenapi/Connection.java
@@ -144,12 +144,18 @@ public class Connection
      * When this constructor is used, a call to dispose() will do nothing. The programmer is responsible for manually
      * logging out the Session.
      */
-    public Connection(URL url, int wait)
+    public Connection(URL url)
     {
         deprecatedConstructorUsed = false;
-        _wait = wait;
         this.client = getClientFromURL(url);
     }
+	
+	public Connection(URL url, int wait) 
+	{
+	    this(url);
+	    _wait = wait;
+    }
+	
 
     /**
      * Creates a connection to a particular server using a given username and password. This object can then be passed

--- a/java/lib/com/xensource/xenapi/XenAPIObject.java
+++ b/java/lib/com/xensource/xenapi/XenAPIObject.java
@@ -33,4 +33,14 @@ package com.xensource.xenapi;
 public abstract class XenAPIObject
 {
 	public abstract String toWireString();
+	
+	/**
+	 * When XAPI returns a null, it actually gets changed into an
+	 * object that contains the string "OpaqueRef:NULL".  This is a
+	 * convenience method to check if a XenAPIObject is in fact
+	 * null in XAPI's eyes.
+	 **/
+	public boolean isNull() {
+	    return toWireString().contains("OpaqueRef:NULL");
+	}
 }


### PR DESCRIPTION
Here's code to add client side timeout for the java stubs.  This timeout is defaulted to be 10 minutes and is meant to isolate the caller and xenserver in case there are problems in xenserver's side in processing the request.  This allows the client to timeout on the client side and return an error back to the caller instead of tying up the thread waiting for a response that may never come.  It is not meant as a retry mechanism. 

The second commit adds a method to check if an object is actually null.  When a XenAPIObject is null, the marshalling code does not set the object as null.  It actually returns an object that contains the words "Opaque:NULL" in them.  This method allows the caller to check this condition without writing the hard coded string themselves.  
