### PR TITLE
CP-7101: Ensure the SDK is using the .NET 2.0 version of CookComputing.X...

### DIFF
--- a/mk/Makefile
+++ b/mk/Makefile
@@ -87,7 +87,11 @@ omake-phase:
 	cd $(REPO) && $(OMAKE) dist
 
 $(MY_OBJ_DIR)/$(XMLRPC_DLL):
-	cp $(PROJECT_OUTPUTDIR)/dotnet-packages-ref/$(XMLRPC_DLL) $@
+ifeq ($(wildcard $(PROJECT_OUTPUTDIR)/dotnet-packages-ref/CookComputing.XmlRpcV2_dotnet2.dll),) 
+	cp $(PROJECT_OUTPUTDIR)/dotnet-packages-ref/CookComputing.XmlRpcV2.dll $@
+else
+	cp $(PROJECT_OUTPUTDIR)/dotnet-packages-ref/CookComputing.XmlRpcV2_dotnet2.dll $@
+endif
 
 $(MY_OBJ_DIR)/csharp_xmlrpc.tar.gz: $(REPO)/mk/sign.bat omake-phase $(MY_OBJ_DIR)/$(XMLRPC_DLL)
 	mkdir -p $(CSHARP_XMLRPC_TMP)


### PR DESCRIPTION
...mlRpcV2_dotnet2.dll.

Signed-off-by: Konstantina Chremmou konstantina.chremmou@citrix.com
