### PR TITLE
Make csharp bindings aware of new msg_doc_tags field

### DIFF
--- a/csharp/gen_csharp_binding.ml
+++ b/csharp/gen_csharp_binding.ml
@@ -561,6 +561,7 @@ and get_all_records_method classname =
     msg_force_custom = None;
     msg_allowed_roles = None;
     msg_map_keys_roles = [];
+    msg_doc_tags = [];
   };
 
 and get_constructor_params content =


### PR DESCRIPTION
This field was recently added to Datamodel_types in the xen-api repo.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>