### PR TITLE
CP-11136: Handle Set(Int) in "exposed_type" functions.

### DIFF
--- a/csharp/gen_csharp_binding.ml
+++ b/csharp/gen_csharp_binding.ml
@@ -1628,6 +1628,7 @@ and exposed_type = function
   | Set(Ref name)           -> sprintf "List<XenRef<%s>>" (exposed_class_name name)
   | Set(Enum(name, _) as x) -> enums := TypeSet.add x !enums;
                                sprintf "List<%s>" name
+  | Set(Int)                -> "long[]"
   | Set(String)             -> "string[]"
   | Enum(name, _) as x      -> enums := TypeSet.add x !enums; name
   | Map(u, v)               -> sprintf "Dictionary<%s, %s>" (exposed_type u)

--- a/powershell/common_functions.ml
+++ b/powershell/common_functions.ml
@@ -147,6 +147,7 @@ and exposed_type = function
   | Ref name                -> sprintf "XenRef<%s>" (qualified_class_name name)
   | Set(Ref name)           -> sprintf "List<XenRef<%s>>" (qualified_class_name name)
   | Set(Enum(name, _))      -> sprintf "List<%s>" name
+  | Set(Int)                -> "long[]"
   | Set(String)             -> "string[]"
   | Enum(name, _)           -> name
   | Map(u, v)               -> sprintf "Dictionary<%s, %s>" (exposed_type u)


### PR DESCRIPTION
First part of a fix.

The work for CP-11136 in xen-api added a field of type Set(Int)
to the Host, to hold the set of Virtual Hardware Platform
Versions that it offers. The "exposed_type" functions here in
the SDK generation code did not handle Set(Int) but threw an
assertion error.  Now they return "long[]".

Still to do: handle Set(Int) in the functions
simple_convert_from_proxy and convert_to_proxy in
csharp/gen_csharp_binding.ml

Signed-off-by: Thomas Sanders <thomas.sanders@citrix.com>