### PR TITLE
Fix duplicated Set(Int) in two matches.

### DIFF
--- a/csharp/gen_csharp_binding.ml
+++ b/csharp/gen_csharp_binding.ml
@@ -1635,7 +1635,6 @@ and exposed_type = function
                                                             (exposed_type v)
   | Record name             -> exposed_class_name name
   | Set(Record name)        -> sprintf "List<%s>" (exposed_class_name name)
-  | Set(Int)                -> sprintf "long[]"
   | _                       -> assert false
 
 

--- a/powershell/common_functions.ml
+++ b/powershell/common_functions.ml
@@ -154,7 +154,6 @@ and exposed_type = function
                                                             (exposed_type v)
   | Record name             -> qualified_class_name name
   | Set(Record name)        -> sprintf "List<%s>" (qualified_class_name name)
-  | Set(Int)                -> sprintf "long[]"
   | _                       -> assert false
 
 and obj_internal_type = function


### PR DESCRIPTION
I had done part of the work to handle Set(Int) and then JonL did a
complete job on a different branch; when his changes were ported to
here they clashed with my change.

Signed-off-by: Thomas Sanders <thomas.sanders@citrix.com>