### PR TITLE
CP-12901: use a pre-populated `message` type

### DIFF
--- a/csharp/gen_csharp_binding.ml
+++ b/csharp/gen_csharp_binding.ml
@@ -541,7 +541,7 @@ namespace XenAPI
 ";
 
 and get_all_records_method classname = 
-  { 
+  { default_message with
     msg_name = "get_all_records";
     msg_params = []; 
     msg_result = Some (Map(Ref classname, Record classname), 


### PR DESCRIPTION
This avoids needing to patch the C# code generator whenever the
`message` record is expanded.

This needs to be merged at the same time as [xapi-project/xen-api#2354]