### PR TITLE
CA-43182: Mark deprecated API calls in the C# and C SDK. Adds comment that stat…

### DIFF
--- a/CommonFunctions.ml
+++ b/CommonFunctions.ml
@@ -121,6 +121,20 @@ and get_first_release_string release =
   if release = "" then ""
   else sprintf "First published in %s." (get_release_name release)
 
+and get_deprecated_info_message_string version = 
+  match version with
+  | None -> ""
+  | Some x -> sprintf "Deprecated since %s" (get_release_name x)
+
+and get_deprecated_attribute_string version =
+  if version =  None then ""
+  else "[Obsolete]"  
+
+and get_deprecated_attribute message =
+  let version = message.msg_release.internal_deprecated_since in
+    get_deprecated_attribute_string version
+
+
 and get_prototyped_release lifecycle =
   match lifecycle with
      | [Prototyped, release, doc] -> release
@@ -143,6 +157,10 @@ and get_published_info_message message cls =
       get_first_release_string msgRelease
     else
       get_first_release_string clsRelease
+
+and get_deprecated_info_message message =
+  let msgDeprecated = message.msg_release.internal_deprecated_since in
+    get_deprecated_info_message_string msgDeprecated
 
 and get_published_info_param message param =
   let msgRelease = get_first_release message.msg_release.internal in 

--- a/CommonFunctions.ml
+++ b/CommonFunctions.ml
@@ -124,16 +124,7 @@ and get_first_release_string release =
 and get_deprecated_info_message_string version = 
   match version with
   | None -> ""
-  | Some x -> sprintf "Deprecated since %s" (get_release_name x)
-
-and get_deprecated_attribute_string version =
-  if version =  None then ""
-  else "[Obsolete]"  
-
-and get_deprecated_attribute message =
-  let version = message.msg_release.internal_deprecated_since in
-    get_deprecated_attribute_string version
-
+  | Some x -> sprintf "Deprecated since %s. " (get_release_name x)
 
 and get_prototyped_release lifecycle =
   match lifecycle with

--- a/c/OMakefile
+++ b/c/OMakefile
@@ -50,7 +50,7 @@ else
   export
 
 section
-  OCamlProgram(gen_c_binding, gen_c_binding helper ../licence)
+  OCamlProgram(gen_c_binding, gen_c_binding helper ../licence ../CommonFunctions)
 
 
 .PHONY: c_source

--- a/c/gen_c_binding.ml
+++ b/c/gen_c_binding.ml
@@ -38,6 +38,9 @@ open Getopt
 
 open Datamodel_types
 open Dm_api
+
+open CommonFunctions
+
 module TypeSet = Set.Make(struct
                 type t = Datamodel_types.ty
                 let compare = compare
@@ -591,14 +594,18 @@ and message_signature needed classname message =
           | None -> []
   in
   let params = joined ", " (param needed) (front @ message.msg_params) in
-    sprintf "bool\n%s(%s)" (messagename classname message.msg_name) params
+  let deprecatedMessage = get_deprecated_info_message message in
+    sprintf "%sbool\n%s(%s)" (if deprecatedMessage = "" then "" else "/*" ^ deprecatedMessage ^ "*/\n")
+                             (messagename classname message.msg_name) params
 
 
 and message_signature_async needed classname message =
   let sessionParam = {param_type=Ref "session"; param_name="session"; param_doc=""; param_release=message.msg_release; param_default = None} in
   let taskParam= {param_type=Ref "task"; param_name="*result"; param_doc=""; param_release=message.msg_release; param_default = None} in
   let params = joined ", " (param needed) (sessionParam :: (taskParam :: message.msg_params)) in
-    sprintf "bool\n%s(%s)" (messagename_async classname message.msg_name) params
+  let deprecatedMessage = get_deprecated_info_message message in
+    sprintf "%sbool\n%s(%s)" (if deprecatedMessage = "" then "" else "/*" ^ deprecatedMessage ^ "*/\n")
+                             (messagename_async classname message.msg_name) params
 
 
 and param needed p =

--- a/csharp/gen_csharp_binding.ml
+++ b/csharp/gen_csharp_binding.ml
@@ -651,29 +651,38 @@ and gen_exposed_method out_chan cls msg curParams =
   let paramsDoc = get_params_doc msg classname curParams in
   let callParams = exposed_call_params msg classname curParams in
   let publishInfo = get_published_info_message msg cls in
+  let deprecatedInfo = get_deprecated_info_message msg in
+  let deprecatedAttribute = get_deprecated_attribute msg in 
+  let deprecatedInfoString = (if deprecatedInfo = "" then "" else "\n        /// "^deprecatedInfo) in
+  let deprecatedAttributeString = (if deprecatedAttribute = "" then "" else "\n        "^deprecatedAttribute) in
   print "
         /// <summary>
-        /// %s%s
-        /// </summary>%s
+        /// %s%s%s
+        /// </summary>%s%s
         public static %s %s(%s)
         {
             %s;
         }\n"
     msg.msg_doc (if publishInfo = "" then "" else "\n        /// "^publishInfo)
+    deprecatedInfoString
     paramsDoc
-    exposed_ret_type msg.msg_name paramSignature
+    deprecatedAttributeString 
+    exposed_ret_type  
+    msg.msg_name paramSignature
     (convert_from_proxy_opt (sprintf "session.proxy.%s(%s).parse()" proxyMsgName callParams) msg.msg_result);
   if msg.msg_async then 
     print "
         /// <summary>
-        /// %s%s
-        /// </summary>%s
+        /// %s%s%s
+        /// </summary>%s%s
         public static XenRef<Task> async_%s(%s)
         {
             return XenRef<Task>.Create(session.proxy.async_%s(%s).parse());
         }\n"
       msg.msg_doc (if publishInfo = "" then "" else "\n        /// "^publishInfo)
+      deprecatedInfoString
       paramsDoc
+      deprecatedAttributeString
       msg.msg_name paramSignature
       proxyMsgName callParams
 

--- a/csharp/gen_csharp_binding.ml
+++ b/csharp/gen_csharp_binding.ml
@@ -67,6 +67,14 @@ Usage:
 " Sys.argv.(0)
 
 
+let get_deprecated_attribute_string version =
+  if version =  None then ""
+  else "[Obsolete]"  
+
+let get_deprecated_attribute message =
+  let version = message.msg_release.internal_deprecated_since in
+    get_deprecated_attribute_string version
+
 let _ =
   try
     ignore (parse_cmdline


### PR DESCRIPTION
…es since what version they have been deprecated and adds an [Obsolete] attribute.