### PR TITLE
Update Initialize-Environment.ps1

### DIFF
--- a/powershell/Initialize-Environment.ps1
+++ b/powershell/Initialize-Environment.ps1
@@ -29,7 +29,7 @@
 #
 
 
-if (Get-Variable XenServer_Environment_Initialized -ValueOnly -ErrorAction SilentlyContinue)
+if((Test-Path variable:XenServer_Environment_Initialized) -eq $true)
 {
     return
 }

--- a/powershell/Initialize-Environment.ps1
+++ b/powershell/Initialize-Environment.ps1
@@ -29,7 +29,7 @@
 #
 
 
-if((Test-Path variable:XenServer_Environment_Initialized) -eq $true)
+if (Get-Variable XenServer_Environment_Initialized -ValueOnly -ErrorAction SilentlyContinue)
 {
     return
 }


### PR DESCRIPTION
Changed to prevent the init procedure from crashing in a "initializationscript" on Start-Job in Powershell. The InitializationScript seems to ignore the "errorAction" setting and terminates the job when the Variable XenServer_Environment_Initialized does not exist. 
I found this way of checking for the variable on stackoverflow (http://stackoverflow.com/questions/3159949/in-powershell-how-do-i-test-whether-or-not-a-specific-variable-exists-in-global). Neat thing on this is that it will not generate a exception when the variable is not set so it should work in an InitializationScript environment as well