### PR TITLE
CP-13394: Build DotNetPackages & C# SDK with .NET 4.5

### DIFF
--- a/csharp/src/XenServer.csproj.header
+++ b/csharp/src/XenServer.csproj.header
@@ -1,4 +1,5 @@
-﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="3.5">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -12,9 +13,11 @@
     <SignAssembly>true</SignAssembly>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
-    <OldToolsVersion>2.0</OldToolsVersion>
+    <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -24,6 +27,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,9 +36,10 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CookComputing.XmlRpcV2, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="CookComputing.XmlRpcV2.dll">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\CookComputing.XmlRpcV2.dll</HintPath>
     </Reference>

--- a/mk/Makefile
+++ b/mk/Makefile
@@ -106,11 +106,7 @@ omake-phase:
 	cd $(REPO) && $(OMAKE) dist
 
 $(MY_OBJ_DIR)/$(XMLRPC_DLL):
-ifeq ($(wildcard $(PROJECT_OUTPUTDIR)/dotnet-packages-ref/CookComputing.XmlRpcV2_dotnet2.dll),) 
 	cp $(PROJECT_OUTPUTDIR)/dotnet-packages-ref/CookComputing.XmlRpcV2.dll $@
-else
-	cp $(PROJECT_OUTPUTDIR)/dotnet-packages-ref/CookComputing.XmlRpcV2_dotnet2.dll $@
-endif
 
 $(MY_OBJ_DIR)/csharp_xmlrpc.tar.gz: $(REPO)/mk/sign.bat omake-phase $(MY_OBJ_DIR)/$(XMLRPC_DLL)
 	mkdir -p $(CSHARP_XMLRPC_TMP)

--- a/mk/csharp.sh
+++ b/mk/csharp.sh
@@ -32,7 +32,7 @@ set -e
 
 FRAMEWORKDIR="${ROOT}/WINDOWS/Microsoft.NET/Framework/v4.0.30319"
 MSBUILD="$FRAMEWORKDIR/MSBuild.exe"
-SDKDIR="${ROOT}/Program Files/Windows Kits/10/bin/x86"
+SDKDIR="${ROOT}/Program Files (x86)/Microsoft SDKs/Windows/v8.0A/bin/NETFX 4.0 Tools"
 RESGEN="$SDKDIR/ResGen.exe"
 SNK="~/.ssh/xs.net.snk"
 

--- a/mk/csharp.sh
+++ b/mk/csharp.sh
@@ -30,9 +30,9 @@
 
 set -e
 
-FRAMEWORKDIR="${ROOT}/WINDOWS/Microsoft.NET/Framework/v3.5"
+FRAMEWORKDIR="${ROOT}/WINDOWS/Microsoft.NET/Framework/v4.0.30319"
 MSBUILD="$FRAMEWORKDIR/MSBuild.exe"
-SDKDIR="${ROOT}/Program Files/Microsoft SDKs/Windows/v6.0A/bin"
+SDKDIR="${ROOT}/Program Files/Windows Kits/10/bin/x86"
 RESGEN="$SDKDIR/ResGen.exe"
 SNK="~/.ssh/xs.net.snk"
 

--- a/mk/powershell.sh
+++ b/mk/powershell.sh
@@ -30,7 +30,7 @@
 
 set -e
 
-FRAMEWORKDIR="${ROOT}/WINDOWS/Microsoft.NET/Framework/v3.5"
+FRAMEWORKDIR="${ROOT}/WINDOWS/Microsoft.NET/Framework/v4.0.30319"
 CSC="$FRAMEWORKDIR/csc.exe"
 # see http://www.interact-sw.co.uk/iangblog/2005/09/12/cmdspawnerror
 SYSPATHS="${ROOT}/WINDOWS/:${ROOT}/WINDOWS/System32:${ROOT}/WINDOWS/System32/wbem"

--- a/mk/sign-ps.bat
+++ b/mk/sign-ps.bat
@@ -30,6 +30,6 @@ rem OF THE POSSIBILITY OF SUCH DAMAGE.
 @echo on
 if not exist C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe goto done
 
-C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -Command "$c = Get-ChildItem \"cert:\\CurrentUser\\My\" | where { $_.Subject -like \"*Citrix Systems, Inc*\" } ; Set-AuthenticodeSignature -cert $c %1" <NUL
+C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -Command "$c = Get-ChildItem -Path cert:\CurrentUser\My, cert:\\LocalMachine\My | where { $_.Subject -like "*Citrix Systems, Inc*" }; Set-AuthenticodeSignature -cert $c %1" <NUL
 
 :done

--- a/powershell/XenServerPSModule.psd1
+++ b/powershell/XenServerPSModule.psd1
@@ -45,7 +45,7 @@ PowerShellVersion = '4.0'
 PowerShellHostName = ''
 PowerShellHostVersion = ''
 DotNetFrameworkVersion = '4.5'
-# CLRVersion = '2.0'
+CLRVersion = '4.0.30319'
 ProcessorArchitecture = 'None'
 
 #Contents

--- a/powershell/XenServerPSModule.psd1
+++ b/powershell/XenServerPSModule.psd1
@@ -41,11 +41,11 @@ CompanyName = 'Citrix Systems, Inc'
 Copyright = 'Copyright (c) Citrix Systems, Inc. All rights reserved.'
 
 # Requirements
-PowerShellVersion = '2.0'
+PowerShellVersion = '4.0'
 PowerShellHostName = ''
 PowerShellHostVersion = ''
-DotNetFrameworkVersion = '3.5'
-CLRVersion = '2.0'
+DotNetFrameworkVersion = '4.5'
+# CLRVersion = '2.0'
 ProcessorArchitecture = 'None'
 
 #Contents

--- a/powershell/src/Connect-XenServer.cs
+++ b/powershell/src/Connect-XenServer.cs
@@ -155,6 +155,7 @@ namespace Citrix.XenServer.Commands
             }
 
             ServicePointManager.ServerCertificateValidationCallback = new RemoteCertificateValidationCallback(ValidateServerCertificate);
+			ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
 
             if (Url == null || Url.Length == 0)
             {

--- a/powershell/src/Connect-XenServer.cs
+++ b/powershell/src/Connect-XenServer.cs
@@ -155,7 +155,7 @@ namespace Citrix.XenServer.Commands
             }
 
             ServicePointManager.ServerCertificateValidationCallback = new RemoteCertificateValidationCallback(ValidateServerCertificate);
-			ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
+			ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
 
             if (Url == null || Url.Length == 0)
             {


### PR DESCRIPTION
This pull request is upgrading the C# SDK to use .net 4.5 as well as making the necessary changes in the PowerShell module