### PR TITLE
CP-9891: SDK: "originator" param for xapi login_with_password (CI-44)

### DIFF
--- a/c/test/test_enumerate.c
+++ b/c/test/test_enumerate.c
@@ -403,7 +403,7 @@ main(int argc, char **argv)
     curl_global_init(CURL_GLOBAL_ALL);
 
     session = xen_session_login_with_password(call_func, NULL, username,
-            password, xen_api_latest_version);
+            password, xen_api_latest_version, "originator_libxenserver_test");
 
     /* get all vm entries */
     if (xen_vm_get_all(session, &vm_set))

--- a/c/test/test_event_handling.c
+++ b/c/test/test_event_handling.c
@@ -169,7 +169,7 @@ int main(int argc, char **argv)
     
     xen_session *session =
         xen_session_login_with_password(call_func, NULL, username, password,
-                                        xen_api_latest_version);
+                                        xen_api_latest_version, "originator_libxenserver_test");
 
     const char* ALL_CLASSES = "*";
     char *all_classes = calloc(1, sizeof(all_classes));

--- a/c/test/test_get_records.c
+++ b/c/test/test_get_records.c
@@ -156,7 +156,8 @@ int main(int argc, char **argv)
 
     
     xen_session *session = xen_session_login_with_password(call_func, NULL,
-                               username, password, xen_api_latest_version);
+                               username, password, xen_api_latest_version,
+                               "originator_libxenserver_test");
 
     
     /* Print some info for hosts */

--- a/c/test/test_vm_async_migrate.c
+++ b/c/test/test_vm_async_migrate.c
@@ -222,7 +222,8 @@ int main(int argc, char **argv)
     
     xen_session *session =
         xen_session_login_with_password(call_func, NULL, username, password,
-                                        xen_api_latest_version);
+                                        xen_api_latest_version,
+                                        "originator_libxenserver_test");
 
     printf("\n\nQuerying host...\n");
     xen_host host;

--- a/c/test/test_vm_ops.c
+++ b/c/test/test_vm_ops.c
@@ -184,7 +184,8 @@ int main(int argc, char **argv)
     
     xen_session *session =
         xen_session_login_with_password(call_func, NULL, username, password,
-                                        xen_api_latest_version);
+                                        xen_api_latest_version,
+                                        "originator_libxenserver_test");
 
     /* ---------------------------------------------------------------------
        Read host, capabilities and API vsn

--- a/c/xen_common.h
+++ b/c/xen_common.h
@@ -201,7 +201,7 @@ void xen_fini(void);
 extern xen_session *
 xen_session_login_with_password(xen_call_func call_func, void *handle,
                                 const char *uname, const char *pwd,
-                                xen_api_version version);
+                                xen_api_version version, const char *originator);
 
 
 /**

--- a/powershell/src/Connect-XenServer.cs
+++ b/powershell/src/Connect-XenServer.cs
@@ -187,7 +187,8 @@ namespace Citrix.XenServer.Commands
                 if (string.IsNullOrEmpty(OpaqueRef[i]))
                 {
                     session = new Session(Url[i]);
-                    session.login_with_password(connUser, connPassword);
+                    var apiVersionString = XenAPI.Helper.APIVersionString(session.APIVersion);
+                    session.login_with_password(connUser, connPassword, apiVersionString, "XenServerPSModule/" + apiVersionString);
                 }
                 else
                 {


### PR DESCRIPTION
This PR implements the change required in the XenServer PowerShell Module.