### PR TITLE
CP-9891: SDK: "originator" param for xapi login_with_password (CI-44)

### DIFF
--- a/powershell/src/Connect-XenServer.cs
+++ b/powershell/src/Connect-XenServer.cs
@@ -187,7 +187,8 @@ namespace Citrix.XenServer.Commands
                 if (string.IsNullOrEmpty(OpaqueRef[i]))
                 {
                     session = new Session(Url[i]);
-                    session.login_with_password(connUser, connPassword);
+                    var apiVersionString = XenAPI.Helper.APIVersionString(session.APIVersion);
+                    session.login_with_password(connUser, connPassword, apiVersionString, "XenServerPSModule/" + apiVersionString);
                 }
                 else
                 {


### PR DESCRIPTION
Modified the PowerShell SDK to call the newest overload of login_with_password XAPI call where the originator field is specified.

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>