### PR TITLE
Cherry-picking CA-249845: Add a retry mechanism around File.Move in the GET function

### DIFF
--- a/csharp/src/HTTP.cs
+++ b/csharp/src/HTTP.cs
@@ -454,7 +454,7 @@ namespace XenAPI
         /// <summary>
         /// A general HTTP GET method, with delegates for progress and cancelling. May throw various exceptions.
         /// </summary>
-        /// <param name="dataRxDelegate">Delegate called periodically (500 ms) with the number of bytes transferred</param>
+        /// <param name="dataCopiedDelegate">Delegate called periodically (500 ms) with the number of bytes transferred</param>
         /// <param name="cancellingDelegate">Delegate called periodically to see if need to cancel</param>
         /// <param name="uri">URI to GET from</param>
         /// <param name="proxy">A proxy to handle the HTTP connection</param>
@@ -474,12 +474,38 @@ namespace XenAPI
                 }
 
                 File.Delete(path);
-                File.Move(tmpFile, path);
+                MoveFileWithRetry(tmpFile, path);
             }
             finally
             {
                 File.Delete(tmpFile);
             }
+        }
+
+        private const int FILE_MOVE_MAX_RETRIES = 5;
+        private const int FILE_MOVE_SLEEP_BETWEEN_RETRIES = 100;
+
+        /// <summary>
+        /// Move a file, retrying a few times with a short sleep between retries.
+        /// If it still fails after these retries, then throw the error.
+        /// </summary>
+        public static void MoveFileWithRetry(string sourceFileName, string destFileName)
+        {
+            int retriesRemaining = FILE_MOVE_MAX_RETRIES;
+            do
+            {
+                try
+                {
+                    File.Move(sourceFileName, destFileName);
+                    break;
+                }
+                catch (IOException)
+                {
+                    if (retriesRemaining <= 0)
+                        throw;
+                    System.Threading.Thread.Sleep(FILE_MOVE_SLEEP_BETWEEN_RETRIES);
+                }
+            } while (retriesRemaining-- > 0);
         }
     }
 }


### PR DESCRIPTION
This is needed because the move operation might fail if there is an anti-virus running on the machine (we are doing the move immediately after we finished writing the file and the anti-virus software might be checking the file at that point)

Signed-off-by: Mihaela Stoica <mihaela.stoica@citrix.com>