### PR TITLE
CA-254480: XenCenter error message refine for CA-205515

### DIFF
--- a/csharp/FriendlyErrorNames.resx
+++ b/csharp/FriendlyErrorNames.resx
@@ -561,6 +561,9 @@
   <data name="POOL_AUTH_ENABLE_FAILED_WRONG_CREDENTIALS" xml:space="preserve">
     <value>Failed to enable external authentication, the supplied credentials were invalid.</value>
   </data>
+  <data name="POOL_AUTH_ENABLE_FAILED_INVALID_ACCOUNT" xml:space="preserve">
+    <value>Failed to enable external authentication, the supplied account was invalid.</value>
+  </data>
   <data name="POOL_JOINING_EXTERNAL_AUTH_MISMATCH" xml:space="preserve">
     <value>The external authentication configuration of the server joining the pool must match the pool's own external authentication configuration.</value>
   </data>


### PR DESCRIPTION
This is another part of pull request on xenserver/xenadmin.
https://github.com/xenserver/xenadmin/pull/1668
Both of them are for a new error message: POOL_AUTH_ENABLE_FAILED_INVALID_ACCOUNT
