### PR TITLE
CA-125488, CA-212616, plus ocp-indentation.

### DIFF
--- a/c/gen_c_binding.ml
+++ b/c/gen_c_binding.ml
@@ -1,19 +1,19 @@
 (*
  * Copyright (c) Citrix Systems, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  *   1) Redistributions of source code must retain the above copyright
  *      notice, this list of conditions and the following disclaimer.
- * 
+ *
  *   2) Redistributions in binary form must reproduce the above
  *      copyright notice, this list of conditions and the following
  *      disclaimer in the documentation and/or other materials
  *      provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -41,9 +41,9 @@ open Dm_api
 open CommonFunctions
 
 module TypeSet = Set.Make(struct
-                type t = Datamodel_types.ty
-                let compare = compare
-              end)
+    type t = Datamodel_types.ty
+    let compare = compare
+  end)
 
 
 let open_source'   = ref false
@@ -66,40 +66,40 @@ let templates_dir = !templates_dir'
 
 
 let api =
-    Datamodel_utils.named_self := true;
+  Datamodel_utils.named_self := true;
 
-    let obj_filter _ = true in
-    let field_filter field =
-        (not field.internal_only) &&
-        (if open_source then List.mem "3.0.3" field.release.opensource
-            else List.mem "closed" field.release.internal)
-    in
-    let message_filter msg =
-        Datamodel_utils.on_client_side msg &&
-        (not msg.msg_hide_from_docs) &&
-        (if open_source then
-                (List.mem "3.0.3" msg.msg_release.opensource)
-            else
-                (List.mem "closed" msg.msg_release.internal)
-                && (msg.msg_name <> "get")
-                && (msg.msg_name <> "get_data_sources"))
-    in
-    filter obj_filter field_filter message_filter
-        (Datamodel_utils.add_implicit_messages ~document_order:false
-            (filter obj_filter field_filter message_filter Datamodel.all_api))
+  let obj_filter _ = true in
+  let field_filter field =
+    (not field.internal_only) &&
+    (if open_source then List.mem "3.0.3" field.release.opensource
+     else List.mem "closed" field.release.internal)
+  in
+  let message_filter msg =
+    Datamodel_utils.on_client_side msg &&
+    (not msg.msg_hide_from_docs) &&
+    (if open_source then
+       (List.mem "3.0.3" msg.msg_release.opensource)
+     else
+       (List.mem "closed" msg.msg_release.internal)
+       && (msg.msg_name <> "get")
+       && (msg.msg_name <> "get_data_sources"))
+  in
+  filter obj_filter field_filter message_filter
+    (Datamodel_utils.add_implicit_messages ~document_order:false
+       (filter obj_filter field_filter message_filter Datamodel.all_api))
 
 let classes = objects_of_api api
 
 
 module StringSet = Set.Make(struct
-                  type t = string
-                  let compare = String.compare
-                end)
+    type t = string
+    let compare = String.compare
+  end)
 
 let enums = ref TypeSet.empty
 let maps = ref TypeSet.empty
 let enum_maps = ref TypeSet.empty
-  let all_headers = ref []
+let all_headers = ref []
 
 let joined sep f l =
   let r = List.map f l in
@@ -119,9 +119,9 @@ let rec main() =
   let filtered_classes = List.filter (fun x-> not (List.mem x.name ["session"; "debug"; "data_source"])) classes in
   List.iter
     (fun x ->
-         (gen_class write_predecl predecl_filename x  include_dir;
-          gen_class write_decl    decl_filename    x  include_dir;
-          gen_class write_impl    impl_filename    x) src_dir) filtered_classes;
+       (gen_class write_predecl predecl_filename x  include_dir;
+        gen_class write_decl    decl_filename    x  include_dir;
+        gen_class write_impl    impl_filename    x) src_dir) filtered_classes;
 
   all_headers := List.map (fun x-> x.name) filtered_classes;
 
@@ -147,31 +147,31 @@ let rec main() =
 and gen_class f g clas targetdir =
   let out_chan = open_out (Filename.concat targetdir (g clas.name))
   in
-    finally (fun () -> f clas out_chan)
-            (fun () -> close_out out_chan)
+  finally (fun () -> f clas out_chan)
+    (fun () -> close_out out_chan)
 
 
 and gen_enum f g targetdir = function
   | Enum(name, contents) ->
-      if not (List.mem name !all_headers) then
-        all_headers := name::!all_headers;
-      let out_chan = open_out (Filename.concat targetdir (g name))
-      in
-        finally (fun () -> f name contents out_chan)
-                (fun () -> close_out out_chan)
+    if not (List.mem name !all_headers) then
+      all_headers := name::!all_headers;
+    let out_chan = open_out (Filename.concat targetdir (g name))
+    in
+    finally (fun () -> f name contents out_chan)
+      (fun () -> close_out out_chan)
 
   | _ -> assert false
 
 
 and gen_map f g targetdir = function
   | Map(l, r) ->
-      let name = mapname l r in
-      if not (List.mem name !all_headers) then
-        all_headers := name::!all_headers;
-      let out_chan = open_out (Filename.concat targetdir (g name))
-      in
-        finally (fun () -> f name l r out_chan)
-                (fun () -> close_out out_chan)
+    let name = mapname l r in
+    if not (List.mem name !all_headers) then
+      all_headers := name::!all_headers;
+    let out_chan = open_out (Filename.concat targetdir (g name))
+    in
+    finally (fun () -> f name l r out_chan)
+      (fun () -> close_out out_chan)
 
   | _ -> assert false
 
@@ -183,21 +183,21 @@ and write_predecl {name=classname} out_chan =
   let record_tn = record_typename classname in
   let record_opt_tn = record_opt_typename classname in
 
-    print_h_header out_chan protect;
+  print_h_header out_chan protect;
 
-    if classname <> "event" then
-      begin
-        print "typedef void *%s;\n\n" tn;
-        print "%s\n" (predecl_set tn);
-      end;
-    print "%s\n" (predecl record_tn);
-    print "%s\n" (predecl_set record_tn);
-    if classname <> "event" then
-      begin
-        print "%s\n" (predecl record_opt_tn);
-        print "%s\n" (predecl_set record_opt_tn);
-      end;
-    print_h_footer out_chan
+  if classname <> "event" then
+    begin
+      print "typedef void *%s;\n\n" tn;
+      print "%s\n" (predecl_set tn);
+    end;
+  print "%s\n" (predecl record_tn);
+  print "%s\n" (predecl_set record_tn);
+  if classname <> "event" then
+    begin
+      print "%s\n" (predecl record_opt_tn);
+      print "%s\n" (predecl_set record_opt_tn);
+    end;
+  print_h_footer out_chan
 
 
 and write_decl {name=classname; contents=contents; description=description;
@@ -213,34 +213,34 @@ and write_decl {name=classname; contents=contents; description=description;
   let record = decl_record needed tn record_tn contents in
   let record_opt = decl_record_opt needed tn record_tn record_opt_tn contents in
   let message_decls = decl_messages needed classname
-    (List.filter (fun x-> not (classname = "event" && x.msg_name = "from")) messages) in
+      (List.filter (fun x-> not (classname = "event" && x.msg_name = "from")) messages) in
   let full_stop = if String.endswith "." description then "" else "."
   in
 
-    print_h_header out_chan protect;
-    print "%s\n" (hash_includes !needed);
+  print_h_header out_chan protect;
+  print "%s\n" (hash_includes !needed);
 
-    print "\n\n%s\n\n\n"
-      (Helper.comment false
-         (sprintf "The %s class.\n\n%s%s" classname description full_stop));
-    
-    if classname <> "event" then
-      begin
-        print "%s\n\n" (decl_free tn (String.lowercase classname) false "handle");
-        print "%s\n" (decl_set tn false);
-      end;
-    print "%s\n" record;
-    if classname <> "event" then
-      begin
-        print "%s\n" record_opt;
-      end;
-    print "%s\n\n" (decl_set record_tn class_has_refs);
-    if classname <> "event" then
-      begin
-        print "%s\n\n" (decl_set record_opt_tn true);
-      end;
-    print "%s\n" message_decls;
-    print_h_footer out_chan
+  print "\n\n%s\n\n\n"
+    (Helper.comment false
+       (sprintf "The %s class.\n\n%s%s" classname description full_stop));
+
+  if classname <> "event" then
+    begin
+      print "%s\n\n" (decl_free tn (String.lowercase classname) false "handle");
+      print "%s\n" (decl_set tn false);
+    end;
+  print "%s\n" record;
+  if classname <> "event" then
+    begin
+      print "%s\n" record_opt;
+    end;
+  print "%s\n\n" (decl_set record_tn class_has_refs);
+  if classname <> "event" then
+    begin
+      print "%s\n\n" (decl_set record_opt_tn true);
+    end;
+  print "%s\n" message_decls;
+  print_h_footer out_chan
 
 
 and predecl_set tn =
@@ -256,7 +256,7 @@ and decl_set tn referenced =
     Helper.comment true
       (sprintf "Allocate a %s_set of the given size." tn) in
 
-    sprintf "
+  sprintf "
 typedef struct %s_set
 {
     size_t size;
@@ -269,7 +269,7 @@ extern %s_set *
 
 %s
 " tn tn tn alloc_com tn tn
-      (decl_free (sprintf "%s_set" tn) "*set" referenced "set")
+    (decl_free (sprintf "%s_set" tn) "*set" referenced "set")
 
 
 and decl_free tn cn referenced thing =
@@ -280,8 +280,8 @@ and decl_free tn cn referenced thing =
          tn
          (if referenced then ", and all referenced values" else "") thing) in
 
-    sprintf
-"%s
+  sprintf
+    "%s
 extern void
 %s_free(%s %s);" com tn tn cn
 
@@ -299,7 +299,7 @@ extern %s *
 
 %s
 " record_tn
-  (if tn <> "xen_event" then sprintf "    %s handle;\n" tn else "")
+    (if tn <> "xen_event" then sprintf "    %s handle;\n" tn else "")
     (record_fields contents needed) record_tn
     (Helper.comment true
        (sprintf "Allocate a %s." record_tn))
@@ -336,11 +336,11 @@ and record_fields contents needed =
 
 and record_field needed prefix content =
   match content with
-    | Field fr ->
+  | Field fr ->
     sprintf "%s%s%s;" (c_type_of_ty needed true fr.ty) prefix
-          (fieldname fr.field_name);
-    | Namespace (p, c) ->
-        joined "\n    " (record_field needed (prefix ^ (fieldname p) ^ "_")) c
+      (fieldname fr.field_name);
+  | Namespace (p, c) ->
+    joined "\n    " (record_field needed (prefix ^ (fieldname p) ^ "_")) c
 
 
 and decl_messages needed classname messages =
@@ -350,21 +350,21 @@ and decl_messages needed classname messages =
 and decl_message needed classname message =
   let message_sig = message_signature needed classname message in
   let messageAsyncVersion = decl_message_async needed classname message in
-    sprintf "%s\n%sextern %s;\n%s" (get_message_comment message) (get_deprecated_message message) message_sig messageAsyncVersion
+  sprintf "%s\n%sextern %s;\n%s" (get_message_comment message) (get_deprecated_message message) message_sig messageAsyncVersion
 
 
 and decl_message_async needed classname message =
   if (message.msg_async) then
-  (
-    let messageSigAsync = message_signature_async needed classname message in
-    needed := StringSet.add "task_decl" !needed;
-    sprintf "\n%s\n%sextern %s;\n" (get_message_comment message) (get_deprecated_message message) messageSigAsync
-  )
+    (
+      let messageSigAsync = message_signature_async needed classname message in
+      needed := StringSet.add "task_decl" !needed;
+      sprintf "\n%s\n%sextern %s;\n" (get_message_comment message) (get_deprecated_message message) messageSigAsync
+    )
   else
     ""
 
 
-and get_message_comment message = 
+and get_message_comment message =
   let full_stop = if String.endswith "." message.msg_doc then "" else "." in
   Helper.comment true (sprintf "%s%s" message.msg_doc full_stop)
 
@@ -377,14 +377,14 @@ and impl_message needed classname message =
   let message_sig = message_signature needed classname message in
   let param_count = List.length message.msg_params in
 
-  let param_decl, param_call = 
+  let param_decl, param_call =
     if param_count = 0 then
       ("", "NULL")
     else
       let param_pieces = abstract_params message.msg_params in
 
-        ((sprintf
-"    abstract_value param_values[] =
+      ((sprintf
+          "    abstract_value param_values[] =
         {
             %s
         };
@@ -393,40 +393,40 @@ and impl_message needed classname message =
 
   let result_bits =
     match message.msg_result with
-      | Some res -> abstract_result_handling needed classname message.msg_name param_count res
-      | None ->
-          sprintf
-"    xen_call_(session, \"%s.%s\", %s, %d, NULL, NULL);
+    | Some res -> abstract_result_handling needed classname message.msg_name param_count res
+    | None ->
+      sprintf
+        "    xen_call_(session, \"%s.%s\", %s, %d, NULL, NULL);
     return session->ok;\n" classname message.msg_name param_call param_count
   in
-  
+
   let messageAsyncImpl=impl_message_async needed classname message in
-    sprintf "%s%s\n{\n%s\n%s}\n%s" (get_deprecated_message message) message_sig param_decl result_bits messageAsyncImpl
+  sprintf "%s%s\n{\n%s\n%s}\n%s" (get_deprecated_message message) message_sig param_decl result_bits messageAsyncImpl
 
 
 and impl_message_async needed classname message =
   if (message.msg_async) then
-  (
+    (
       let messageSigAsync = message_signature_async needed classname message in
       let param_count = List.length message.msg_params in
 
-      let param_decl, param_call = 
+      let param_decl, param_call =
         if param_count = 0 then
           ("", "NULL")
         else
           let param_pieces = abstract_params message.msg_params in
 
-            ((sprintf
-"    abstract_value param_values[] =
+          ((sprintf
+              "    abstract_value param_values[] =
         {
             %s
         };
 " param_pieces), "param_values")
       in
-      
+
       let result_bits = abstract_result_handling_async needed classname message.msg_name param_count in
-        sprintf "\n%s%s\n{\n%s\n%s}" (get_deprecated_message message) messageSigAsync param_decl result_bits
-  )
+      sprintf "\n%s%s\n{\n%s\n%s}" (get_deprecated_message message) messageSigAsync param_decl result_bits
+    )
   else
     ""
 
@@ -445,7 +445,7 @@ and abstract_param p =
 and abstract_param_conv name = function
   | Set _
   | Map _ ->
-      sprintf "(arbitrary_set *)%s" (paramname name)
+    sprintf "(arbitrary_set *)%s" (paramname name)
   | Ref "session" -> sprintf "%s->session_id" (paramname name)
   | _ -> paramname name
 
@@ -464,33 +464,33 @@ and abstract_member = function
 
 and abstract_result_handling needed classname msg_name param_count = function
     typ, _ ->
-      let call =
-        if param_count = 0 then
-          sprintf "xen_call_(session, \"%s.%s\", NULL, 0, &result_type, result);" classname msg_name
-        else
-          sprintf "XEN_CALL_(\"%s.%s\");" classname msg_name
-      in
+    let call =
+      if param_count = 0 then
+        sprintf "xen_call_(session, \"%s.%s\", NULL, 0, &result_type, result);" classname msg_name
+      else
+        sprintf "XEN_CALL_(\"%s.%s\");" classname msg_name
+    in
 
-        match typ with
-            String
-          | Ref _
-          | Int
-          | Float
-          | Bool
-          | DateTime
-          | Set _
-          | Map _ ->
-              sprintf
-"%s
+    match typ with
+      String
+    | Ref _
+    | Int
+    | Float
+    | Bool
+    | DateTime
+    | Set _
+    | Map _ ->
+      sprintf
+        "%s
 
 %s    %s
     return session->ok;
 " (abstract_result_type typ) (initialiser_of_ty typ) call
 
-          | Record n ->
-              let record_tn = record_typename n in
-                sprintf
-"    abstract_type result_type = %s_abstract_type_;
+    | Record n ->
+      let record_tn = record_typename n in
+      sprintf
+        "    abstract_type result_type = %s_abstract_type_;
 
 %s    %s
 
@@ -502,23 +502,23 @@ and abstract_result_handling needed classname msg_name param_count = function
     return session->ok;
 " record_tn (initialiser_of_ty (Record n)) call
 
-          | Enum(e, _) ->
-              sprintf
-"%s
+    | Enum(e, _) ->
+      sprintf
+        "%s
     %s
     return session->ok;
 " (abstract_result_type typ) call
 
 
 and abstract_result_handling_async needed classname msg_name param_count =
-      let call =
-        if param_count = 0 then
-          sprintf "xen_call_(session, \"Async.%s.%s\", NULL, 0, &result_type, result);" classname msg_name
-        else
-          sprintf "XEN_CALL_(\"Async.%s.%s\");" classname msg_name
-      in
-        sprintf
-"    abstract_type result_type = abstract_type_string;
+  let call =
+    if param_count = 0 then
+      sprintf "xen_call_(session, \"Async.%s.%s\", NULL, 0, &result_type, result);" classname msg_name
+    else
+      sprintf "XEN_CALL_(\"Async.%s.%s\");" classname msg_name
+  in
+  sprintf
+    "    abstract_type result_type = abstract_type_string;
 
     *result = NULL;
     %s
@@ -526,49 +526,49 @@ and abstract_result_handling_async needed classname msg_name param_count =
 
 and abstract_record_field classname prefix prefix_caps content =
   match content with
-      Field fr ->
-        let fn = fieldname fr.field_name in
+    Field fr ->
+    let fn = fieldname fr.field_name in
     sprintf "{ .key = \"%s%s\",
           .type = &%s,
           .offset = offsetof(%s, %s%s) }"
-          prefix_caps fr.field_name (abstract_type true fr.ty)
-          (record_typename classname) prefix fn;
-    | Namespace (p, c) ->
-        joined ",\n        " (abstract_record_field classname
-                                (prefix ^ (fieldname p) ^ "_")
-                                (prefix_caps ^ p ^ "_")) c
+      prefix_caps fr.field_name (abstract_type true fr.ty)
+      (record_typename classname) prefix fn;
+  | Namespace (p, c) ->
+    joined ",\n        " (abstract_record_field classname
+                            (prefix ^ (fieldname p) ^ "_")
+                            (prefix_caps ^ p ^ "_")) c
 
 and abstract_result_type typ =
   let ab_typ = abstract_type false typ in
-    sprintf "    abstract_type result_type = %s;" ab_typ
+  sprintf "    abstract_type result_type = %s;" ab_typ
 
 
 and abstract_type record = function
   | String      -> "abstract_type_string"
   | Enum(n, _)  ->
-      sprintf "%s_abstract_type_" (typename n)
+    sprintf "%s_abstract_type_" (typename n)
   | Ref _       ->
-      if record then
-        "abstract_type_ref"
-      else
-        "abstract_type_string"
+    if record then
+      "abstract_type_ref"
+    else
+      "abstract_type_string"
   | Int         -> "abstract_type_int"
   | Float       -> "abstract_type_float"
   | Bool        -> "abstract_type_bool"
   | DateTime    -> "abstract_type_datetime"
   | Set (Enum(n, _)) ->
-      sprintf "%s_set_abstract_type_" (typename n)
+    sprintf "%s_set_abstract_type_" (typename n)
   | Set (Record "event") ->
-      "xen_event_record_set_abstract_type_"
+    "xen_event_record_set_abstract_type_"
   | Set memtype -> (abstract_type record memtype) ^ "_set"
   | Map(Ref(_), Ref(_)) ->
-      if record then "abstract_type_string_ref_map" else "abstract_type_string_string_map"
+    if record then "abstract_type_string_ref_map" else "abstract_type_string_string_map"
   | Map(Ref(_), r) -> sprintf "abstract_type_string_%s_map" (name_of_ty r)
   | Map(l, Ref(_)) ->
-      if record then
-        sprintf "abstract_type_%s_ref_map" (name_of_ty l)
-      else
-        sprintf "abstract_type_%s_string_map" (name_of_ty l)
+    if record then
+      sprintf "abstract_type_%s_ref_map" (name_of_ty l)
+    else
+      sprintf "abstract_type_%s_string_map" (name_of_ty l)
   | Map((Enum(_,_) as l), r) -> (mapname l r) ^ "_abstract_type_"
   | Map(l, (Enum(_,_) as r)) -> (mapname l r) ^ "_abstract_type_"
   | Map(l, r) -> sprintf "abstract_type_" ^ (mapname l r)
@@ -577,25 +577,25 @@ and abstract_type record = function
 
 and get_deprecated_message message =
   let deprecatedMessage = get_deprecated_info_message message in
-    if deprecatedMessage = "" then sprintf "" else sprintf "/* " ^ deprecatedMessage ^ " */\n"
+  if deprecatedMessage = "" then sprintf "" else sprintf "/* " ^ deprecatedMessage ^ " */\n"
 
 
 and message_signature needed classname message =
-  let front = 
+  let front =
     {param_type=Ref "session"; param_name="session"; param_doc=""; param_release=message.msg_release; param_default = None} ::
-        match message.msg_result with
-            Some res -> [{param_type=fst res; param_name="*result"; param_doc=""; param_release=message.msg_release; param_default = None}]
-          | None -> []
+    match message.msg_result with
+      Some res -> [{param_type=fst res; param_name="*result"; param_doc=""; param_release=message.msg_release; param_default = None}]
+    | None -> []
   in
   let params = joined ", " (param needed) (front @ message.msg_params) in
-    sprintf "bool\n%s(%s)" (messagename classname message.msg_name) params
+  sprintf "bool\n%s(%s)" (messagename classname message.msg_name) params
 
 
 and message_signature_async needed classname message =
   let sessionParam = {param_type=Ref "session"; param_name="session"; param_doc=""; param_release=message.msg_release; param_default = None} in
   let taskParam= {param_type=Ref "task"; param_name="*result"; param_doc=""; param_release=message.msg_release; param_default = None} in
   let params = joined ", " (param needed) (sessionParam :: (taskParam :: message.msg_params)) in
-    sprintf "bool\n%s(%s)" (messagename_async classname message.msg_name) params
+  sprintf "bool\n%s(%s)" (messagename_async classname message.msg_name) params
 
 
 and param needed p =
@@ -606,11 +606,11 @@ and param needed p =
 
 and hash_includes needed =
   String.concat "\n"
-    (List.sort 
+    (List.sort
        String.compare
        (List.filter
-         (function s -> s <> "")
-         (List.map hash_include ("common" :: StringSet.elements needed))))
+          (function s -> s <> "")
+          (List.map hash_include ("common" :: StringSet.elements needed))))
 
 
 and hash_include n =
@@ -628,9 +628,9 @@ and write_enum_decl name contents out_chan =
   let protect = protector name in
   let tn = typename name in
 
-    print_h_header out_chan protect;
- 
-    print "
+  print_h_header out_chan protect;
+
+  print "
 %s
 
 
@@ -663,36 +663,36 @@ extern enum %s
 %s_from_string(xen_session *session, const char *str);
 
 " (hash_include "common") tn
-      (joined ",\n\n" (enum_entry name)
-         (contents @
-            [("undefined", "Unknown to this version of the bindings.")]))
-      tn tn tn
-      (Helper.comment true
-         (sprintf "Allocate a %s_set of the given size." tn))
-      tn tn
-      (decl_free (sprintf "%s_set" tn) "*set" false "set")
-      (Helper.comment true
-         "Return the name corresponding to the given code.  This string must not be modified or freed.")
-      tn tn
-      (Helper.comment true
-         "Return the correct code for the given string, or set the session object to failure and return an undefined value if the given string does not match a known code.")
-      tn tn;
+    (joined ",\n\n" (enum_entry name)
+       (contents @
+        [("undefined", "Unknown to this version of the bindings.")]))
+    tn tn tn
+    (Helper.comment true
+       (sprintf "Allocate a %s_set of the given size." tn))
+    tn tn
+    (decl_free (sprintf "%s_set" tn) "*set" false "set")
+    (Helper.comment true
+       "Return the name corresponding to the given code.  This string must not be modified or freed.")
+    tn tn
+    (Helper.comment true
+       "Return the correct code for the given string, or set the session object to failure and return an undefined value if the given string does not match a known code.")
+    tn tn;
 
-    print_h_footer out_chan
+  print_h_footer out_chan
 
 
 and enum_entry enum_name = function
     (n, c) ->
-      sprintf "%s\n    XEN_%s_%s" (Helper.comment true ~indent:4 c)
-        (String.uppercase enum_name) (String.replace "-" "_" (String.uppercase n))
+    sprintf "%s\n    XEN_%s_%s" (Helper.comment true ~indent:4 c)
+      (String.uppercase enum_name) (String.replace "-" "_" (String.uppercase n))
 
 
 and write_enum_impl name contents out_chan =
   let print format = fprintf out_chan format in
   let tn = typename name in
-    
-    print
-"%s
+
+  print
+    "%s
 
 #include <string.h>
 
@@ -751,18 +751,18 @@ const abstract_type %s_abstract_type_ =
 
 
 " Licence.bsd_two_clause (hash_include "internal") (hash_include name)
-      (hash_include (name ^ "_internal"))
-      (enum_lookup_entries
-         (contents @ [("undefined", "")]))
-      tn tn tn tn
-      tn tn
-      tn tn tn tn
-      tn tn tn;
+    (hash_include (name ^ "_internal"))
+    (enum_lookup_entries
+       (contents @ [("undefined", "")]))
+    tn tn tn tn
+    tn tn
+    tn tn tn tn
+    tn tn tn;
 
   if name <> "event_operation"
   then
     print
-"const abstract_type %s_set_abstract_type_ =
+      "const abstract_type %s_set_abstract_type_ =
     {
         .typename = SET,
         .child = &%s_abstract_type_
@@ -778,7 +778,7 @@ and enum_lookup_entries contents =
 
 and enum_lookup_entry = function
     n, _ ->
-      sprintf "    \"%s\"" n
+    sprintf "    \"%s\"" n
 
 
 and write_enum_internal_decl name contents out_chan =
@@ -788,14 +788,14 @@ and write_enum_internal_decl name contents out_chan =
 
   let set_abstract_type =
     (if name = "event_operations"
-    then
-        ""
-    else
-        sprintf "extern const abstract_type %s_set_abstract_type_;\n" tn)
+     then
+       ""
+     else
+       sprintf "extern const abstract_type %s_set_abstract_type_;\n" tn)
   in
-    
-    print
-"%s
+
+  print
+    "%s
 
 
 %s
@@ -813,10 +813,10 @@ extern const abstract_type %s_abstract_type_;
 
 #endif
 " Licence.bsd_two_clause
-      (Helper.comment false (sprintf "Declarations of the abstract types used during demarshalling of enum %s.  Internal to this library -- do not use from outside." tn))
-      protect protect
-      (hash_include "internal") tn
-      set_abstract_type
+    (Helper.comment false (sprintf "Declarations of the abstract types used during demarshalling of enum %s.  Internal to this library -- do not use from outside." tn))
+    protect protect
+    (hash_include "internal") tn
+    set_abstract_type
 
 
 and write_map_decl name l r out_chan =
@@ -828,8 +828,8 @@ and write_map_decl name l r out_chan =
     Helper.comment true
       (sprintf "Allocate a %s of the given size." tn) in
 
-    print_h_header out_chan protect;
-    print "
+  print_h_header out_chan protect;
+  print "
 %s%s%s
 
 
@@ -853,11 +853,11 @@ extern %s *
 %s
 
 " (hash_include "common") (hash_include_enum l) (hash_include_enum r)
-      tn
-      (c_type_of_ty needed false l)
-      (c_type_of_ty needed true r) tn tn tn tn
-      alloc_com tn tn (decl_free tn "*map" true "map");
-    print_h_footer out_chan
+    tn
+    (c_type_of_ty needed false l)
+    (c_type_of_ty needed true r) tn tn tn tn
+    alloc_com tn tn (decl_free tn "*map" true "map");
+  print_h_footer out_chan
 
 and write_map_impl name l r out_chan =
   let print format = fprintf out_chan format in
@@ -865,19 +865,19 @@ and write_map_impl name l r out_chan =
   let l_free_impl = free_impl "map->contents[i].key" false l in
   let r_free_impl = free_impl "map->contents[i].val" true r in
   let needed = ref StringSet.empty in
-    find_needed'' needed l;
-    find_needed'' needed r;
-    needed := StringSet.add "internal" !needed;
-    needed := StringSet.add name !needed;
-    begin
-      match r with
-          Set(String) ->
-            needed := StringSet.add ("string_set") !needed
-        | _ -> ()
-    end;
+  find_needed'' needed l;
+  find_needed'' needed r;
+  needed := StringSet.add "internal" !needed;
+  needed := StringSet.add name !needed;
+  begin
+    match r with
+      Set(String) ->
+      needed := StringSet.add ("string_set") !needed
+    | _ -> ()
+  end;
 
-    print
-"%s
+  print
+    "%s
 
 
 %s
@@ -897,12 +897,12 @@ void
 %s_free(%s *map)
 {
 " Licence.bsd_two_clause (hash_includes !needed) tn tn tn tn
-  (String.make (String.length tn) ' ') tn tn tn;
+    (String.make (String.length tn) ' ') tn tn tn;
 
-    if (String.compare l_free_impl "" != 0 ||
-        String.compare r_free_impl "" != 0) then
-      print
-"    if (map == NULL)
+  if (String.compare l_free_impl "" != 0 ||
+      String.compare r_free_impl "" != 0) then
+    print
+      "    if (map == NULL)
     {
         return;
     }
@@ -916,22 +916,22 @@ void
 
 " l_free_impl r_free_impl;
 
-    print
-"    free(map);
+  print
+    "    free(map);
 }
 ";
 
-   begin
-     match l, r with
-         (Enum(_, _), _) -> gen_enum_map_abstract_type print name l r
-       | (_, Enum(_, _)) -> gen_enum_map_abstract_type print name l r
-       | _ -> ()
-   end
+  begin
+    match l, r with
+      (Enum(_, _), _) -> gen_enum_map_abstract_type print name l r
+    | (_, Enum(_, _)) -> gen_enum_map_abstract_type print name l r
+    | _ -> ()
+  end
 
 
 and gen_enum_map_abstract_type print name l r =
   let tn = mapname l r in
-    print "
+  print "
 
 static const struct_member %s_struct_members[] =
     {
@@ -950,9 +950,9 @@ const abstract_type %s_abstract_type_ =
        .members = %s_struct_members
     };
 " tn
-  (abstract_type false l) tn
-  (abstract_type false r) tn
-  tn tn tn tn
+    (abstract_type false l) tn
+    (abstract_type false r) tn
+    tn tn tn tn
 
 
 and write_enum_map_internal_decl name l r out_chan =
@@ -969,20 +969,20 @@ extern const abstract_type %s_abstract_type_;
 
 and hash_include_enum = function
     Enum(x, _) ->
-      "\n" ^ hash_include x
+    "\n" ^ hash_include x
   | _ ->
-      ""
+    ""
 
 and gen_failure_h () =
   let protect = protector "api_failure" in
   let out_chan = open_out (Filename.concat destdir "include/xen/api/xen_api_failure.h")
   in
   finally (fun () ->
-             print_h_header out_chan protect;
-             gen_failure_enum out_chan;
-             gen_failure_funcs out_chan;
-             print_h_footer out_chan)
-          (fun () -> close_out out_chan)
+      print_h_header out_chan protect;
+      gen_failure_enum out_chan;
+      gen_failure_funcs out_chan;
+      print_h_footer out_chan)
+    (fun () -> close_out out_chan)
 
 and gen_failure_enum out_chan =
   let print format = fprintf out_chan format in
@@ -1000,19 +1000,19 @@ and failure_enum_entries() =
   let r = Hashtbl.fold failure_enum_entry Datamodel.errors [] in
   let r = List.sort (fun (x, _) (y, _) -> String.compare y x) r in
   let r = failure_enum_entry "UNDEFINED"
-    { err_doc = "Unknown to this version of the bindings.";
-      err_params = [];
-      err_name = "UNDEFINED"; } r
+      { err_doc = "Unknown to this version of the bindings.";
+        err_params = [];
+        err_name = "UNDEFINED"; } r
   in
   (List.map (fun (x, y) -> y) (List.rev r))
 
 
 and failure_enum_entry name err acc =
   (name, sprintf
-"%s
+     "%s
     %s"
      (Helper.comment true ~indent:4 err.Datamodel_types.err_doc)
-      (failure_enum name)) :: acc
+     (failure_enum name)) :: acc
 
 
 and gen_failure_funcs out_chan =
@@ -1027,10 +1027,10 @@ extern enum xen_api_failure
 xen_api_failure_from_string(const char *str);
 
 "
-      (Helper.comment true
-         "Return the name corresponding to the given code.  This string must not be modified or freed.")
-      (Helper.comment true
-         "Return the correct code for the given string, or UNDEFINED if the given string does not match a known code.")
+    (Helper.comment true
+       "Return the name corresponding to the given code.  This string must not be modified or freed.")
+    (Helper.comment true
+       "Return the correct code for the given string, or UNDEFINED if the given string does not match a known code.")
 
 
 and gen_failure_c () =
@@ -1038,7 +1038,7 @@ and gen_failure_c () =
   let print format = fprintf out_chan format
   in
   finally (fun () ->
-             print "%s
+      print "%s
 
 #include \"xen_internal.h\"
 #include <xen/api/xen_api_failure.h>
@@ -1068,8 +1068,8 @@ xen_api_failure_from_string(const char *str)
 
 
 " Licence.bsd_two_clause
-  (String.concat ",\n    " (failure_lookup_entries out_chan)))
-          (fun () -> close_out out_chan)
+        (String.concat ",\n    " (failure_lookup_entries out_chan)))
+    (fun () -> close_out out_chan)
 
 and failure_lookup_entries out_chan =
   List.sort String.compare
@@ -1092,7 +1092,7 @@ and write_impl {name=classname; contents=contents; messages=messages} out_chan =
   let msgs =
     impl_messages needed classname
       (List.filter (fun x-> not (classname = "event" && x.msg_name = "from")) messages)
- in
+  in
   let record_free_handle =
     if classname = "event" then "" else "    free(record->handle);\n" in
   let record_free_impls =
@@ -1103,9 +1103,9 @@ and write_impl {name=classname; contents=contents; messages=messages} out_chan =
   let record_fields =
     joined ",\n        " (abstract_record_field classname "" "") filtered_record_fields in
   let needed = ref StringSet.empty in
-    find_needed needed messages;
-    needed := StringSet.add "internal" !needed;
-    needed := StringSet.add classname !needed;
+  find_needed needed messages;
+  needed := StringSet.add "internal" !needed;
+  needed := StringSet.add classname !needed;
 
   let getAllRecordsExists = List.exists (fun x -> x.msg_name = "get_all_records") messages in
   let mappingName = sprintf "%s_%s" tn record_tn in
@@ -1121,10 +1121,10 @@ and write_impl {name=classname; contents=contents; messages=messages} out_chan =
           [sprintf "XEN_ALLOC(%s)" record_opt_tn;
            sprintf "XEN_RECORD_OPT_FREE(%s)" tn;
            sprintf "XEN_SET_ALLOC_FREE(%s)" record_opt_tn]))
-       in
+  in
 
-    print
-"%s
+  print
+    "%s
 
 
 #include <stddef.h>
@@ -1139,8 +1139,8 @@ and write_impl {name=classname; contents=contents; messages=messages} out_chan =
 " Licence.bsd_two_clause (hash_includes !needed) free_block;
 
 
-    print
-"static const struct_member %s_struct_members[] =
+  print
+    "static const struct_member %s_struct_members[] =
     {
         %s
     };
@@ -1157,17 +1157,17 @@ const abstract_type %s_abstract_type_ =
 
 " record_tn record_fields record_tn record_tn record_tn record_tn;
 
-    if classname = "event" then
-      print
-"const abstract_type %s_set_abstract_type_ =
+  if classname = "event" then
+    print
+      "const abstract_type %s_set_abstract_type_ =
     {
        .typename = SET,
         .child = &%s_abstract_type_
     };\n\n\n" record_tn record_tn;
 
-    if getAllRecordsExists then
-      print
-"static const struct struct_member %s_members[] =
+  if getAllRecordsExists then
+    print
+      "static const struct struct_member %s_members[] =
 {
     {
         .type = &abstract_type_string,
@@ -1186,8 +1186,8 @@ const abstract_type abstract_type_string_%s_map =
     .members = %s_members
 };\n\n\n" mappingName mappingName record_tn mappingName record_tn mappingName mappingName;
 
-    print
-"void
+  print
+    "void
 %s_free(%s *record)
 {
     if (record == NULL)
@@ -1198,7 +1198,7 @@ const abstract_type abstract_type_string_%s_map =
     free(record);
 }\n\n\n" record_tn record_tn record_free_handle record_free_impls;
 
-    print "%s\n" msgs
+  print "%s\n" msgs
 
 
 and find_needed needed messages =
@@ -1208,10 +1208,10 @@ and find_needed needed messages =
 and find_needed' needed message =
   List.iter (fun p -> find_needed'' needed p.param_type) message.msg_params;
   match message.msg_result with
-      Some (x, _) ->
-        find_needed'' needed x
-    | None ->
-        ()
+    Some (x, _) ->
+    find_needed'' needed x
+  | None ->
+    ()
 
 
 and find_needed'' needed = function
@@ -1221,24 +1221,24 @@ and find_needed'' needed = function
   | Bool
   | DateTime -> ()
   | Enum (n, _) ->
-      needed := StringSet.add (n ^ "_internal") !needed
+    needed := StringSet.add (n ^ "_internal") !needed
   | Ref n ->
-      needed := StringSet.add n !needed
+    needed := StringSet.add n !needed
   | Set(Ref n) ->
-      needed := StringSet.add n !needed
+    needed := StringSet.add n !needed
   | Set(Enum (e, _)) ->
-      needed := StringSet.add e !needed;
-      needed := StringSet.add (e ^ "_internal") !needed
+    needed := StringSet.add e !needed;
+    needed := StringSet.add (e ^ "_internal") !needed
   | Set(Record "event") ->
-      needed := StringSet.add ("event_operation_internal") !needed
+    needed := StringSet.add ("event_operation_internal") !needed
   | Map(l, r) ->
-      let n = mapname l r in
-        needed := StringSet.add n !needed;
-        needed := add_enum_map_internal !needed l r;
-        needed := add_enum_internal !needed l;
-        needed := add_enum_internal !needed r
+    let n = mapname l r in
+    needed := StringSet.add n !needed;
+    needed := add_enum_map_internal !needed l r;
+    needed := add_enum_internal !needed l;
+    needed := add_enum_internal !needed r
   | _ ->
-      ()
+    ()
 
 and record_free_impl prefix = function
   | Field fr         -> free_impl (prefix ^ (fieldname fr.field_name)) true fr.ty
@@ -1257,7 +1257,7 @@ and free_impl val_name record = function
   | Set(Enum (e, _)) -> sprintf "%s_set_free(%s);" (typename e) val_name
   | Set(String)      -> sprintf "xen_string_set_free(%s);" val_name
   | Map(l, r)        -> let n = mapname l r in
-                        sprintf "%s_free(%s);" (typename n) val_name
+    sprintf "%s_free(%s);" (typename n) val_name
   | Record x         -> sprintf "%s_free(%s);" (record_typename x) val_name
   | Set(Int)         -> sprintf "xen_int_set_free(%s);" val_name
   | _                -> "DONT_KNOW"
@@ -1283,49 +1283,49 @@ and c_type_of_ty needed record = function
   | DateTime            -> "time_t "
   | Ref "session"       -> "xen_session *"
   | Ref name            ->
-      needed := StringSet.add (name ^ "_decl") !needed;
-      if record then
-        sprintf "struct %s *" (record_opt_typename name)
-      else
-        sprintf "%s " (typename name)
+    needed := StringSet.add (name ^ "_decl") !needed;
+    if record then
+      sprintf "struct %s *" (record_opt_typename name)
+    else
+      sprintf "%s " (typename name)
   | Enum(name, cs) as x ->
-      needed := StringSet.add name !needed;
-      enums := TypeSet.add x !enums;
-      c_type_of_enum name
+    needed := StringSet.add name !needed;
+    enums := TypeSet.add x !enums;
+    c_type_of_enum name
   | Set (Ref name) ->
-      needed := StringSet.add (name ^ "_decl") !needed;
-      if record then
-        sprintf "struct %s_set *" (record_opt_typename name)
-      else
-        sprintf "struct %s_set *" (typename name)
+    needed := StringSet.add (name ^ "_decl") !needed;
+    if record then
+      sprintf "struct %s_set *" (record_opt_typename name)
+    else
+      sprintf "struct %s_set *" (typename name)
   | Set (Enum (e, _) as x) ->
-      let enum_typename = typename e in
-        needed := StringSet.add e !needed;
-        enums := TypeSet.add x !enums;
-        sprintf "struct %s_set *" enum_typename
+    let enum_typename = typename e in
+    needed := StringSet.add e !needed;
+    enums := TypeSet.add x !enums;
+    sprintf "struct %s_set *" enum_typename
   | Set(String) ->
-      needed := StringSet.add "string_set" !needed;
-      "struct xen_string_set *"
+    needed := StringSet.add "string_set" !needed;
+    "struct xen_string_set *"
   | Set (Record "event") -> "struct xen_event_record_set *"
   | Set (Int)            ->
-      needed := StringSet.add "int_set" !needed;
-      "struct xen_int_set *"
+    needed := StringSet.add "int_set" !needed;
+    "struct xen_int_set *"
   | Set _                -> "SET_DONT_KNOW"
   | Map(l, r) as x ->
-      let n = mapname l r in
-        needed := StringSet.add n !needed;
-        maps := TypeSet.add x !maps;
-        begin
-          match (l, r) with
-              (Enum(_, _), _) -> enum_maps := TypeSet.add x !enum_maps
-            | (_, Enum(_, _)) -> enum_maps := TypeSet.add x !enum_maps
-            | _ -> ()
-        end;
-        sprintf "%s *" (typename n)
+    let n = mapname l r in
+    needed := StringSet.add n !needed;
+    maps := TypeSet.add x !maps;
+    begin
+      match (l, r) with
+        (Enum(_, _), _) -> enum_maps := TypeSet.add x !enum_maps
+      | (_, Enum(_, _)) -> enum_maps := TypeSet.add x !enum_maps
+      | _ -> ()
+    end;
+    sprintf "%s *" (typename n)
   | Record n -> if record then
-                  sprintf "struct %s *" (record_typename n)
-                else
-                  sprintf "%s *" (record_typename n)
+      sprintf "struct %s *" (record_typename n)
+    else
+      sprintf "%s *" (record_typename n)
 
 
 and c_type_of_enum name =
@@ -1359,7 +1359,7 @@ and name_of_ty = function
 
 and decl_filename name =
   let dir = (if String.endswith "internal" name then "" else "xen/api/") in
-    sprintf "%sxen_%s.h" dir (String.lowercase name)
+  sprintf "%sxen_%s.h" dir (String.lowercase name)
 
 
 and predecl_filename name =
@@ -1408,8 +1408,8 @@ and messagename_async classname name =
     (String.lowercase name)
 
 and keyword_map name =
-	let keywords = ["class","XEN_CLAZZ"; "public", "pubblic"] in
-	if List.mem_assoc name keywords then List.assoc name keywords else name
+  let keywords = ["class","XEN_CLAZZ"; "public", "pubblic"] in
+  if List.mem_assoc name keywords then List.assoc name keywords else name
 
 and paramname name =
   keyword_map (String.lowercase name)
@@ -1421,9 +1421,9 @@ and fieldname name =
 
 and print_h_header out_chan protect =
   let print format = fprintf out_chan format in
-    print "%s\n\n" Licence.bsd_two_clause;
-    print "#ifndef %s\n" protect;
-    print "#define %s\n\n" protect;
+  print "%s\n\n" Licence.bsd_two_clause;
+  print "#ifndef %s\n" protect;
+  print "#define %s\n\n" protect;
 
 and print_h_footer out_chan =
   fprintf out_chan "\n#endif\n"

--- a/c/helper.ml
+++ b/c/helper.ml
@@ -1,19 +1,19 @@
 (*
  * Copyright (c) Citrix Systems, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  *   1) Redistributions of source code must retain the above copyright
  *      notice, this list of conditions and the following disclaimer.
- * 
+ *
  *   2) Redistributions in binary form must reproduce the above
  *      copyright notice, this list of conditions and the following
  *      disclaimer in the documentation and/or other materials
  *      provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -30,25 +30,25 @@
 
 open Stdext.Xstringext
 
-let rec formatted_wrap formatter s = 
+let rec formatted_wrap formatter s =
   let split_in_2 c s =
     match String.split ~limit:2 c s with
-        h :: t -> (h, if t = [] then "" else List.hd t)
-      | [] -> assert false
+      h :: t -> (h, if t = [] then "" else List.hd t)
+    | [] -> assert false
   in
   let prespace, postspace = split_in_2 ' ' s in
   let preeol, posteol = split_in_2 '\n' s in
 
-    if String.length prespace < String.length preeol then
-      (Format.fprintf formatter "%s@ " prespace;
-       if String.length postspace > 0 then
-         formatted_wrap formatter postspace)
-    else
-      (if String.length posteol > 0 then
-         (Format.fprintf formatter "%s@\n" preeol;
-          formatted_wrap formatter posteol)
-       else
-         Format.fprintf formatter "%s@ " preeol)
+  if String.length prespace < String.length preeol then
+    (Format.fprintf formatter "%s@ " prespace;
+     if String.length postspace > 0 then
+       formatted_wrap formatter postspace)
+  else
+    (if String.length posteol > 0 then
+       (Format.fprintf formatter "%s@\n" preeol;
+        formatted_wrap formatter posteol)
+     else
+       Format.fprintf formatter "%s@ " preeol)
 
 let comment doc ?(indent = 0) s =
   let indent_str = String.make indent ' ' in
@@ -58,35 +58,35 @@ let comment doc ?(indent = 0) s =
 
   let out, flush, newline, spaces =
     let funcs = Format.pp_get_formatter_out_functions formatter () in
-      (funcs.out_string, funcs.out_flush, funcs.out_newline, funcs.out_spaces)
+    (funcs.out_string, funcs.out_flush, funcs.out_newline, funcs.out_spaces)
   in
 
-    let funcs = {
-      out_string = out;
-      out_flush = flush;
-      out_newline = (fun () ->
-                  out (Printf.sprintf "\n%s * " indent_str) 0 (indent + 4));
-      out_spaces = spaces;
-    } in
-    Format.pp_set_formatter_out_functions formatter funcs;
- 
-    Format.pp_open_hvbox formatter 0;
-    Format.pp_set_margin formatter 76;
-    Format.fprintf formatter "%s" indent_str;
-    Format.fprintf formatter "/*";
-    if doc then
-      Format.fprintf formatter "*";
-    Format.fprintf formatter "\n";
-    Format.fprintf formatter "%s" indent_str;
-    Format.fprintf formatter " * ";
+  let funcs = {
+    out_string = out;
+    out_flush = flush;
+    out_newline = (fun () ->
+        out (Printf.sprintf "\n%s * " indent_str) 0 (indent + 4));
+    out_spaces = spaces;
+  } in
+  Format.pp_set_formatter_out_functions formatter funcs;
 
-    formatted_wrap formatter s;
-    Format.pp_close_box formatter ();
+  Format.pp_open_hvbox formatter 0;
+  Format.pp_set_margin formatter 76;
+  Format.fprintf formatter "%s" indent_str;
+  Format.fprintf formatter "/*";
+  if doc then
+    Format.fprintf formatter "*";
+  Format.fprintf formatter "\n";
+  Format.fprintf formatter "%s" indent_str;
+  Format.fprintf formatter " * ";
 
-    Format.fprintf formatter "%!";
+  formatted_wrap formatter s;
+  Format.pp_close_box formatter ();
 
-    Format.pp_set_formatter_out_functions formatter { funcs with out_newline=newline };
-      
-    let result = Buffer.contents buf in
-    let n = String.length result in
-      String.sub result 0 (n - 1) ^ "/"
+  Format.fprintf formatter "%!";
+
+  Format.pp_set_formatter_out_functions formatter { funcs with out_newline=newline };
+
+  let result = Buffer.contents buf in
+  let n = String.length result in
+  String.sub result 0 (n - 1) ^ "/"

--- a/common/CommonFunctions.ml
+++ b/common/CommonFunctions.ml
@@ -1,19 +1,19 @@
 (*
  * Copyright (c) Citrix Systems, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  *   1) Redistributions of source code must retain the above copyright
  *      notice, this list of conditions and the following disclaimer.
- * 
+ *
  *   2) Redistributions in binary form must reproduce the above
  *      copyright notice, this list of conditions and the following
  *      disclaimer in the documentation and/or other materials
  *      provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -39,21 +39,21 @@ let rec list_distinct list =
   | []                  -> []
   | [x]                 -> [x]
   | hd1::(hd2::_ as tl) -> if hd1 = hd2 then list_distinct tl
-                             else hd1::(list_distinct tl)           
+    else hd1::(list_distinct tl)
 
 let rec list_last = function
   | x::[]  -> x
   | hd::tl -> list_last tl
   | []     -> failwith "Cannot return the last element of an empty list."
 
-and list_index_of x list = 
+and list_index_of x list =
   let rec index_rec i = function
     | []     -> raise Not_found
     | hd::tl -> if hd = x then i else index_rec (i+1) tl
   in
   try
     index_rec 0 list
-    with Not_found -> -1
+  with Not_found -> -1
 
 let rec gen_param_groups_for_releases releaseOrder params =
   match releaseOrder with
@@ -83,12 +83,12 @@ and gen_param_groups message params =
   let msgReleaseIndex = list_index_of msgRelease code_name_order in
   let paramGroups = gen_param_groups_for_releases code_name_order params in
   let rec getValid x = match x with
-                       | [] -> []
-                       | hd::tl -> let index = list_index_of (fst hd) code_name_order in
-                                   let valid = if (not (index = -1)) && (not (msgReleaseIndex = -1)) && (index < msgReleaseIndex) then []
-                                               else snd hd in
-                                   valid::(getValid tl)
-                     in
+    | [] -> []
+    | hd::tl -> let index = list_index_of (fst hd) code_name_order in
+      let valid = if (not (index = -1)) && (not (msgReleaseIndex = -1)) && (index < msgReleaseIndex) then []
+        else snd hd in
+      valid::(getValid tl)
+  in
   let filteredGroups = List.filter (fun x -> match x with | [] -> false | _ -> true) (getValid paramGroups) in
   if (not (expRelease = "")) then
     [params]
@@ -103,77 +103,77 @@ and get_release_name codename =
 
 and get_first_release releases =
   let filtered = List.filter (fun x -> List.mem x releases) code_name_order in
-    match filtered with
-    | []     -> ""
-    | hd::tl -> hd
+  match filtered with
+  | []     -> ""
+  | hd::tl -> hd
 
 and get_first_release_string release =
   if release = "" then ""
   else sprintf "First published in %s." (get_release_name release)
 
-and get_deprecated_info_message_string version = 
+and get_deprecated_info_message_string version =
   match version with
   | None -> ""
   | Some x -> sprintf "Deprecated since %s." (get_release_name x)
 
 and get_prototyped_release lifecycle =
   match lifecycle with
-     | [Prototyped, release, doc] -> release
-     | _                          -> ""
+  | [Prototyped, release, doc] -> release
+  | _                          -> ""
 
 and get_prototyped_release_string lifecycle =
   match lifecycle with
-     | [Prototyped, release, doc] -> "Experimental. "^(get_first_release_string release)
-     | _                          -> ""
+  | [Prototyped, release, doc] -> "Experimental. "^(get_first_release_string release)
+  | _                          -> ""
 
 and get_published_info_message message cls =
-  let expRelease = get_prototyped_release_string message.msg_lifecycle in 
-  let clsRelease = get_first_release cls.obj_release.internal in 
+  let expRelease = get_prototyped_release_string message.msg_lifecycle in
+  let clsRelease = get_first_release cls.obj_release.internal in
   let msgRelease =  get_first_release message.msg_release.internal in
   let clsReleaseIndex = list_index_of clsRelease code_name_order in
   let msgReleaseIndex = list_index_of msgRelease code_name_order in
-    if (not (expRelease = "")) then
-      expRelease
-    else if (not (clsReleaseIndex = -1)) && (not (msgReleaseIndex = -1)) && (clsReleaseIndex < msgReleaseIndex) then
-      get_first_release_string msgRelease
-    else
-      get_first_release_string clsRelease
+  if (not (expRelease = "")) then
+    expRelease
+  else if (not (clsReleaseIndex = -1)) && (not (msgReleaseIndex = -1)) && (clsReleaseIndex < msgReleaseIndex) then
+    get_first_release_string msgRelease
+  else
+    get_first_release_string clsRelease
 
 and get_deprecated_info_message message =
   let msgDeprecated = message.msg_release.internal_deprecated_since in
-    get_deprecated_info_message_string msgDeprecated
+  get_deprecated_info_message_string msgDeprecated
 
 and get_published_info_param message param =
-  let msgRelease = get_first_release message.msg_release.internal in 
+  let msgRelease = get_first_release message.msg_release.internal in
   let paramRelease = get_first_release param.param_release.internal in
   let msgReleaseIndex = list_index_of msgRelease code_name_order in
   let paramReleaseIndex = list_index_of paramRelease code_name_order in
-    if (not (msgReleaseIndex = -1)) && (not (paramReleaseIndex = -1)) && (msgReleaseIndex < paramReleaseIndex) then
-      get_first_release_string paramRelease
-    else ""
+  if (not (msgReleaseIndex = -1)) && (not (paramReleaseIndex = -1)) && (msgReleaseIndex < paramReleaseIndex) then
+    get_first_release_string paramRelease
+  else ""
 
 and get_published_info_class cls =
   get_first_release_string (get_first_release cls.obj_release.internal)
 
 and get_published_info_field field cls =
   let expRelease = get_prototyped_release_string field.lifecycle in
-  let clsRelease = get_first_release cls.obj_release.internal in 
+  let clsRelease = get_first_release cls.obj_release.internal in
   let fieldRelease =  get_first_release field.release.internal in
   let clsReleaseIndex = list_index_of clsRelease code_name_order in
   let fieldReleaseIndex = list_index_of fieldRelease code_name_order in
-    if (not (expRelease = "")) then
-      expRelease
-    else if (not (clsReleaseIndex = -1)) && (not (fieldReleaseIndex = -1)) && (clsReleaseIndex < fieldReleaseIndex) then
-      get_first_release_string fieldRelease
-    else
-      ""
+  if (not (expRelease = "")) then
+    expRelease
+  else if (not (clsReleaseIndex = -1)) && (not (fieldReleaseIndex = -1)) && (clsReleaseIndex < fieldReleaseIndex) then
+    get_first_release_string fieldRelease
+  else
+    ""
 
 and render_template template_file json output_file =
   let templ = Stdext.Unixext.string_of_file template_file |> Mustache.of_string in
   let rendered = Mustache.render templ json in
   let out_chan = open_out output_file in
   finally (fun () -> output_string out_chan rendered)
-          (fun () -> close_out out_chan)
+    (fun () -> close_out out_chan)
 
 let render_file (infile,outfile) json templates_dir dest_dir=
   let input_path = Filename.concat templates_dir infile in
@@ -182,19 +182,19 @@ let render_file (infile,outfile) json templates_dir dest_dir=
 
 let json_releases =
   let json_of_rel x y = `O [
-    "code_name", `String (code_name_of_release_ext x);
-    "version_major", `Float (float_of_int x.version_major);
-    "version_minor", `Float (float_of_int x.version_minor);
-    "branding", `String x.branding;
-    "version_index", `Float (float_of_int y);
+      "code_name", `String (code_name_of_release_ext x);
+      "version_major", `Float (float_of_int x.version_major);
+      "version_minor", `Float (float_of_int x.version_minor);
+      "branding", `String x.branding;
+      "version_index", `Float (float_of_int y);
     ]
   in
   let rec get_unique l =
     match l with
     | [] -> []
     | hd::tl ->
-        let remove_duplicates = List.filter (fun x -> not (x.version_major = hd.version_major && x.version_minor = hd.version_minor)) in
-        hd::(get_unique (remove_duplicates tl))
+      let remove_duplicates = List.filter (fun x -> not (x.version_major = hd.version_major && x.version_minor = hd.version_minor)) in
+      hd::(get_unique (remove_duplicates tl))
   in
   let unique_version_bumps = get_unique release_order_full in
   `O [ "API_VERSION_MAJOR", `Float (Int64.to_float Datamodel.api_version_major);

--- a/common/licence.ml
+++ b/common/licence.ml
@@ -1,19 +1,19 @@
 (*
  * Copyright (c) Citrix Systems, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  *   1) Redistributions of source code must retain the above copyright
  *      notice, this list of conditions and the following disclaimer.
- * 
+ *
  *   2) Redistributions in binary form must reproduce the above
  *      copyright notice, this list of conditions and the following
  *      disclaimer in the documentation and/or other materials
  *      provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -31,19 +31,19 @@
 let bsd_two_clause = "/*
  * Copyright (c) Citrix Systems, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  *   1) Redistributions of source code must retain the above copyright
  *      notice, this list of conditions and the following disclaimer.
- * 
+ *
  *   2) Redistributions in binary form must reproduce the above
  *      copyright notice, this list of conditions and the following
  *      disclaimer in the documentation and/or other materials
  *      provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS

--- a/csharp/friendly_error_names.ml
+++ b/csharp/friendly_error_names.ml
@@ -1,19 +1,19 @@
 (*
  * Copyright (c) Citrix Systems, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  *   1) Redistributions of source code must retain the above copyright
  *      notice, this list of conditions and the following disclaimer.
- * 
+ *
  *   2) Redistributions in binary form must reproduce the above
  *      copyright notice, this list of conditions and the following
  *      disclaimer in the documentation and/or other materials
  *      provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -43,9 +43,9 @@ let rec friendly_names_all errors =
   let keys   = Hashtbl.fold get_keys friendly_names [] in
   let keys'  = List.sort String.compare keys in
   let values = List.map get_value keys' in
-    List.combine keys' values;
+  List.combine keys' values;
 
-and update_entries _ error = 
+and update_entries _ error =
   let name = error.DT.err_name in
   let desc = error.DT.err_doc in
   if not (Hashtbl.mem friendly_names name) then
@@ -56,7 +56,7 @@ and update_entries _ error =
 and get_keys key _ tail =
   key :: tail
 
-and get_value key = 
+and get_value key =
   Hashtbl.find friendly_names key
 
 let rec get_node k = function
@@ -68,34 +68,34 @@ let parse_sr_xml filename =
   let update_entry children =
     let description = get_node "description" children in
     let value = get_node "value" children in
-      Hashtbl.replace friendly_names ("SR_BACKEND_FAILURE_" ^ value) description
+    Hashtbl.replace friendly_names ("SR_BACKEND_FAILURE_" ^ value) description
   in
   let rec parse_xml = function
     | Xml.Element("SM-errorcodes", _, children) -> List.iter parse_xml children
     | Xml.Element("code", _, children)          -> update_entry children
     | _                                         -> ()
   in
-    try
-      parse_xml (Xml.parse_file filename)
-    with
-      Xml.Error e as exn ->
-        Printf.eprintf "%s\n%!" (Xml.error e);
-        raise exn
+  try
+    parse_xml (Xml.parse_file filename)
+  with
+    Xml.Error e as exn ->
+    Printf.eprintf "%s\n%!" (Xml.error e);
+    raise exn
 
 let parse_resx filename =
   let update_entry attrs children =
     let key = List.assoc "name" attrs in
     let value = get_node "value" children in
-      Hashtbl.replace friendly_names key value
+    Hashtbl.replace friendly_names key value
   in
   let rec parse_xml = function
     | Xml.Element("root", _, children)     -> List.iter parse_xml children
     | Xml.Element("data", attrs, children) -> update_entry attrs children
     | _                                    -> ()
   in
-    try
-      parse_xml (Xml.parse_file filename)
-    with
-      Xml.Error e as exn ->
-        Printf.eprintf "%s\n%!" (Xml.error e);
-        raise exn
+  try
+    parse_xml (Xml.parse_file filename)
+  with
+    Xml.Error e as exn ->
+    Printf.eprintf "%s\n%!" (Xml.error e);
+    raise exn

--- a/csharp/gen_csharp_binding.ml
+++ b/csharp/gen_csharp_binding.ml
@@ -1,19 +1,19 @@
 (*
  * Copyright (c) Citrix Systems, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  *   1) Redistributions of source code must retain the above copyright
  *      notice, this list of conditions and the following disclaimer.
- * 
+ *
  *   2) Redistributions in binary form must reproduce the above
  *      copyright notice, this list of conditions and the following
  *      disclaimer in the documentation and/or other materials
  *      provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -43,9 +43,9 @@ module DT = Datamodel_types
 module DU = Datamodel_utils
 
 module TypeSet = Set.Make(struct
-			    type t = DT.ty
-			    let compare = compare
-			  end)
+    type t = DT.ty
+    let compare = compare
+  end)
 
 let open_source' = ref false
 let destdir'    = ref ""
@@ -56,11 +56,11 @@ let templdir'     = ref ""
 let get_deprecated_attribute_string version =
   match version with
   | None -> ""
-  | Some versionString -> "[Deprecated(\"" ^ get_release_name versionString ^ "\")]"  
+  | Some versionString -> "[Deprecated(\"" ^ get_release_name versionString ^ "\")]"
 
 let get_deprecated_attribute message =
   let version = message.msg_release.internal_deprecated_since in
-    get_deprecated_attribute_string version
+  get_deprecated_attribute_string version
 
 let _ =
   Arg.parse
@@ -82,24 +82,24 @@ let templdir = !templdir'
 
 
 let api =
-	Datamodel_utils.named_self := true;
+  Datamodel_utils.named_self := true;
 
-	let obj_filter _ = true in
-	let field_filter field =
-		(not field.internal_only) &&
-		((not open_source && (List.mem "closed" field.release.internal)) ||
-		(open_source && (List.mem "3.0.3" field.release.opensource)))
-	in
-	let message_filter msg = 
-		Datamodel_utils.on_client_side msg &&
-		(* XXX: C# binding generates get_all_records some other way *)
-		(msg.msg_tag <> (FromObject GetAllRecords)) && 
-		((not open_source && (List.mem "closed" msg.msg_release.internal)) ||
-		(open_source && (List.mem "3.0.3" msg.msg_release.opensource)))
-	in
-	filter obj_filter field_filter message_filter
-		(Datamodel_utils.add_implicit_messages ~document_order:false
-			(filter obj_filter field_filter message_filter Datamodel.all_api))
+  let obj_filter _ = true in
+  let field_filter field =
+    (not field.internal_only) &&
+    ((not open_source && (List.mem "closed" field.release.internal)) ||
+     (open_source && (List.mem "3.0.3" field.release.opensource)))
+  in
+  let message_filter msg =
+    Datamodel_utils.on_client_side msg &&
+    (* XXX: C# binding generates get_all_records some other way *)
+    (msg.msg_tag <> (FromObject GetAllRecords)) &&
+    ((not open_source && (List.mem "closed" msg.msg_release.internal)) ||
+     (open_source && (List.mem "3.0.3" msg.msg_release.opensource)))
+  in
+  filter obj_filter field_filter message_filter
+    (Datamodel_utils.add_implicit_messages ~document_order:false
+       (filter obj_filter field_filter message_filter Datamodel.all_api))
 
 let classes = objects_of_api api
 let enums = ref TypeSet.empty
@@ -122,7 +122,7 @@ let escape s =
     | '"' -> "\\\""
     | c -> String.make 1 c
   in
-    String.concat "" (List.map esc_char (String.explode s))
+  String.concat "" (List.map esc_char (String.explode s))
 
 let enum_of_wire = String.replace "-" "_"
 
@@ -150,7 +150,7 @@ and gen_relations() =
   let print format = fprintf out_chan format in
   List.iter process_relations (relations_of_api api);
   print
-"%s
+    "%s
 
 using System;
 using System.Collections.Generic;
@@ -175,20 +175,20 @@ namespace XenAPI
             Dictionary<Type, Relation[]> relations = new Dictionary<Type, Relation[]>();
 
 " Licence.bsd_two_clause;
-    Hashtbl.iter (gen_relations_by_type out_chan) relations;
-    print
-"
+  Hashtbl.iter (gen_relations_by_type out_chan) relations;
+  print
+    "
             return relations;
        }
     }
 }
 "
-and string_ends str en = 
+and string_ends str en =
   let len = String.length en in
-    String.sub str ((String.length str) - len) len = en
+  String.sub str ((String.length str) - len) len = en
 
-and process_relations ((oneClass, oneField), (manyClass, manyField)) = 
-  let value = 
+and process_relations ((oneClass, oneField), (manyClass, manyField)) =
+  let value =
     try
       (manyField, oneClass, oneField) :: (Hashtbl.find relations manyClass)
     with Not_found ->
@@ -196,19 +196,19 @@ and process_relations ((oneClass, oneField), (manyClass, manyField)) =
         [(manyField, oneClass, oneField)]
       end
   in
-    Hashtbl.replace relations manyClass value
+  Hashtbl.replace relations manyClass value
 
 and gen_relations_by_type out_chan manyClass relations =
   let print format = fprintf out_chan format in
-    print "            relations.Add(typeof(Proxy_%s), new Relation[] {\n" (exposed_class_name manyClass);
-    
-    List.iter (gen_relation out_chan) relations;
-    
-    print "            });\n\n";
-    
+  print "            relations.Add(typeof(Proxy_%s), new Relation[] {\n" (exposed_class_name manyClass);
+
+  List.iter (gen_relation out_chan) relations;
+
+  print "            });\n\n";
+
 and gen_relation out_chan (manyField, oneClass, oneField) =
   let print format = fprintf out_chan format in
-    print "                new Relation(\"%s\", \"%s\", \"%s\"),\n" manyField oneClass oneField
+  print "                new Relation(\"%s\", \"%s\", \"%s\"),\n" manyField oneClass oneField
 
 (* ------------------- category: http_actions *)
 
@@ -217,7 +217,7 @@ and gen_http_actions() =
   let print format = fprintf out_chan format in
 
   let print_header() = print
-"%s
+      "%s
 
 using System;
 using System.Text;
@@ -238,7 +238,7 @@ namespace XenAPI
         {
             HTTP.Put(progressDelegate, cancellingDelegate, HTTP.BuildUri(hostname, remotePath, args), proxy, localPath, timeout_ms);
         }"
-    Licence.bsd_two_clause
+      Licence.bsd_two_clause
   in
 
   let print_footer() = print "\n    }\n}\n" in
@@ -292,15 +292,15 @@ namespace XenAPI
 
   let print_one_action(name, (meth, uri, sdk, sdkargs, _, _)) =
     match sdk with
-      | false -> ()
-      | true -> print_one_action_core name meth uri sdkargs
+    | false -> ()
+    | true -> print_one_action_core name meth uri sdkargs
   in
 
-  print_header(); 
+  print_header();
   List.iter print_one_action http_actions;
   print_footer();
 
-(* ------------------- category: classes *)
+  (* ------------------- category: classes *)
 
 
 and gen_class_file cls =
@@ -309,8 +309,8 @@ and gen_class_file cls =
     api_members := m::!api_members;
   let out_chan = open_out (Filename.concat destdir (exposed_class_name cls.name)^".cs")
   in
-    finally (fun () -> gen_class out_chan cls)
-            (fun () -> close_out out_chan)
+  finally (fun () -> gen_class out_chan cls)
+    (fun () -> close_out out_chan)
 
 and gen_class out_chan cls =
   let print format = fprintf out_chan format in
@@ -320,7 +320,7 @@ and gen_class out_chan cls =
   let publishedInfo = get_published_info_class cls in
 
   print
-"%s
+    "%s
 
 using System;
 using System.Collections;
@@ -337,14 +337,14 @@ namespace XenAPI
     public partial class %s : XenObject<%s>
     {"
 
-  Licence.bsd_two_clause
-  cls.description (if publishedInfo = "" then "" else "\n    /// "^publishedInfo)
-  exposed_class_name exposed_class_name;
+    Licence.bsd_two_clause
+    cls.description (if publishedInfo = "" then "" else "\n    /// "^publishedInfo)
+    exposed_class_name exposed_class_name;
 
   (* Generate bits for Message type *)
   if cls.name = "message" then
     begin
-    print "
+      print "
         public enum MessageType { %s };
 
         public MessageType Type
@@ -353,14 +353,14 @@ namespace XenAPI
             {
                 switch (this.name)
                 {"
-      (String.concat ", " ((List.map fst !Api_messages.msgList) @ ["unknown"]));
-    
-    List.iter (fun x -> print "
+        (String.concat ", " ((List.map fst !Api_messages.msgList) @ ["unknown"]));
+
+      List.iter (fun x -> print "
                     case \"%s\":
                         return MessageType.%s;" x x) (List.map fst !Api_messages.msgList);
 
-    print
-"
+      print
+        "
                     default:
                         return MessageType.unknown;
                 }
@@ -370,29 +370,29 @@ namespace XenAPI
     end;
 
   print
-"
+    "
         public %s()
         {
         }
 "
-  exposed_class_name;
+    exposed_class_name;
 
   let print_internal_ctor = function
     | []            -> ()
     | _ as cnt -> print
-"
+                    "
         public %s(%s)
         {
             %s
         }
 "
-  exposed_class_name
-  (String.concat ",\n            " (List.rev (get_constructor_params cnt)))
-  (String.concat "\n            " (List.rev (get_constructor_body cnt)))
+                    exposed_class_name
+                    (String.concat ",\n            " (List.rev (get_constructor_params cnt)))
+                    (String.concat "\n            " (List.rev (get_constructor_body cnt)))
   in print_internal_ctor contents;
 
   print
-"
+    "
         /// <summary>
         /// Creates a new %s from a Proxy_%s.
         /// </summary>
@@ -405,36 +405,36 @@ namespace XenAPI
         public override void UpdateFrom(%s update)
         {
 "
-  exposed_class_name exposed_class_name
-  exposed_class_name exposed_class_name
-  exposed_class_name;
+    exposed_class_name exposed_class_name
+    exposed_class_name exposed_class_name
+    exposed_class_name;
 
   List.iter (gen_updatefrom_line out_chan) contents;
 
   print
-"        }
+    "        }
 
         internal void UpdateFromProxy(Proxy_%s proxy)
         {
 "
-  exposed_class_name;
+    exposed_class_name;
 
   List.iter (gen_constructor_line out_chan) contents;
 
   print
-"        }
+    "        }
 
         public Proxy_%s ToProxy()
         {
             Proxy_%s result_ = new Proxy_%s();
 "
-  exposed_class_name
-  exposed_class_name exposed_class_name;
+    exposed_class_name
+    exposed_class_name exposed_class_name;
 
   List.iter (gen_to_proxy_line out_chan) contents;
 
   print
-"            return result_;
+    "            return result_;
         }
 ";
 
@@ -446,12 +446,12 @@ namespace XenAPI
         public %s(Hashtable table)
         {
 "
-  exposed_class_name exposed_class_name;
+    exposed_class_name exposed_class_name;
 
   List.iter (gen_hashtable_constructor_line out_chan) contents;
 
   print
-"        }
+    "        }
 
         ";
 
@@ -465,14 +465,14 @@ namespace XenAPI
             if (ReferenceEquals(this, other))
                 return true;" in
   (match current_ops with
-    | [] ->
-      print "public bool DeepEquals(%s other)
+   | [] ->
+     print "public bool DeepEquals(%s other)
         {
             %s
 
             return " exposed_class_name check_refs
-    | _ ->
-      print "public bool DeepEquals(%s other, bool ignoreCurrentOperations)
+   | _ ->
+     print "public bool DeepEquals(%s other, bool ignoreCurrentOperations)
         {
             %s
 
@@ -482,8 +482,8 @@ namespace XenAPI
             return " exposed_class_name check_refs);
 
   (match other_contents with
-     | [] -> print "false"
-     | _ ->  print "%s" (String.concat " &&
+   | [] -> print "false"
+   | _ ->  print "%s" (String.concat " &&
                 " (List.map gen_equals_condition other_contents)));
 
   print ";
@@ -494,33 +494,33 @@ namespace XenAPI
             if (opaqueRef == null)
             {
 "
-  exposed_class_name;
+    exposed_class_name;
 
   if cls.gen_constructor_destructor then
     print
-"                Proxy_%s p = this.ToProxy();
+      "                Proxy_%s p = this.ToProxy();
                 return session.proxy.%s_create(session.uuid, p).parse();
 "
-    exposed_class_name (String.lowercase exposed_class_name)
-    else
-      print
-"                System.Diagnostics.Debug.Assert(false, \"Cannot create instances of this type on the server\");
+      exposed_class_name (String.lowercase exposed_class_name)
+  else
+    print
+      "                System.Diagnostics.Debug.Assert(false, \"Cannot create instances of this type on the server\");
                 return \"\";
 ";
 
-      print
-"            }
+  print
+    "            }
             else
             {
 ";
 
-    gen_save_changes out_chan exposed_class_name messages contents;
+  gen_save_changes out_chan exposed_class_name messages contents;
 
-    print
-"
+  print
+    "
             }
         }";
- 
+
   List.iter (gen_exposed_method_overloads out_chan cls) (List.filter (fun x -> not x.msg_hide_from_docs) messages);
 
   (* Don't create duplicate get_all_records call *)
@@ -531,21 +531,21 @@ namespace XenAPI
   List.iter (gen_exposed_field out_chan cls) contents;
 
   print
-"    }
+    "    }
 }
 ";
 
-and get_all_records_method classname = 
+and get_all_records_method classname =
   { default_message with
     msg_name = "get_all_records";
-    msg_params = []; 
-    msg_result = Some (Map(Ref classname, Record classname), 
-                  sprintf "A map from %s to %s.Record" classname classname);
+    msg_params = [];
+    msg_result = Some (Map(Ref classname, Record classname),
+                       sprintf "A map from %s to %s.Record" classname classname);
     msg_doc = sprintf "Get all the %s Records at once, in a single XML RPC call" classname;
     msg_session = true; msg_async = false;
-    msg_release = {opensource=["3.0.3"]; internal=["closed"; "debug"]; internal_deprecated_since=None}; 
+    msg_release = {opensource=["3.0.3"]; internal=["closed"; "debug"]; internal_deprecated_since=None};
     msg_lifecycle = [];
-    msg_has_effect = false; msg_tag = Custom; 
+    msg_has_effect = false; msg_tag = Custom;
     msg_obj_name = classname;
     msg_errors = []; msg_secret = false;
     msg_custom_marshaller = false;
@@ -565,8 +565,8 @@ and get_constructor_params content =
 and get_constructor_params' content elements =
   match content with
     [] -> elements
-    | (Field fr)::others -> get_constructor_params' others ((sprintf "%s %s" (exposed_type fr.ty) (full_name fr))::elements)
-    | (Namespace (_, c))::others -> get_constructor_params' (c@others) elements
+  | (Field fr)::others -> get_constructor_params' others ((sprintf "%s %s" (exposed_type fr.ty) (full_name fr))::elements)
+  | (Namespace (_, c))::others -> get_constructor_params' (c@others) elements
 
 and get_constructor_body content =
   get_constructor_body' content []
@@ -574,64 +574,64 @@ and get_constructor_body content =
 and get_constructor_body' content elements =
   match content with
     [] -> elements
-    | (Field fr)::others -> get_constructor_body' others ((sprintf "this.%s = %s;" (full_name fr) (full_name fr))::elements)
-    | (Namespace (_, c))::others -> get_constructor_body' (c@others) elements
+  | (Field fr)::others -> get_constructor_body' others ((sprintf "this.%s = %s;" (full_name fr) (full_name fr))::elements)
+  | (Namespace (_, c))::others -> get_constructor_body' (c@others) elements
 
 and gen_constructor_line out_chan content =
   let print format = fprintf out_chan format in
 
   match content with
-      Field fr ->
-          print
-"            %s = %s;
+    Field fr ->
+    print
+      "            %s = %s;
 " (full_name fr) (convert_from_proxy ("proxy." ^ (full_name fr)) fr.ty)
 
-    | Namespace (_, c) -> List.iter (gen_constructor_line out_chan) c
+  | Namespace (_, c) -> List.iter (gen_constructor_line out_chan) c
 
 and gen_hashtable_constructor_line out_chan content =
   let print format = fprintf out_chan format in
 
   match content with
-    | Field fr ->
-          print
-"            %s = %s;
+  | Field fr ->
+    print
+      "            %s = %s;
 " (full_name fr) (convert_from_hashtable (full_name fr) fr.ty)
 
-    | Namespace (_, c) -> List.iter (gen_hashtable_constructor_line out_chan) c
+  | Namespace (_, c) -> List.iter (gen_hashtable_constructor_line out_chan) c
 
 and gen_equals_condition content =
   match content with
-    | Field fr -> "Helper.AreEqual2(this._" ^ (full_name fr) ^ ", other._" ^ (full_name fr) ^ ")"
-    | Namespace (_, c) -> String.concat " &&
+  | Field fr -> "Helper.AreEqual2(this._" ^ (full_name fr) ^ ", other._" ^ (full_name fr) ^ ")"
+  | Namespace (_, c) -> String.concat " &&
                 " (List.map gen_equals_condition c);
 
 and gen_updatefrom_line out_chan content =
   let print format = fprintf out_chan format in
 
   match content with
-      Field fr ->
-          print
-"            %s = %s;
+    Field fr ->
+    print
+      "            %s = %s;
 " (full_name fr) ("update." ^ (full_name fr))
-    | Namespace (_, c) -> List.iter (gen_updatefrom_line out_chan) c
+  | Namespace (_, c) -> List.iter (gen_updatefrom_line out_chan) c
 
 and gen_to_proxy_line out_chan content =
   let print format = fprintf out_chan format in
 
   match content with
-      Field fr ->
-          print
-"            result_.%s = %s;
+    Field fr ->
+    print
+      "            result_.%s = %s;
 " (full_name fr) (convert_to_proxy (full_name fr) fr.ty)
 
-    | Namespace (_, c) -> List.iter (gen_to_proxy_line out_chan) c
+  | Namespace (_, c) -> List.iter (gen_to_proxy_line out_chan) c
 
 and gen_overload out_chan classname message generator =
   let methodParams = get_method_params_list message in
-    match methodParams with
-    | [] -> generator []
-    | _  -> let paramGroups =  gen_param_groups message methodParams in
-              List.iter generator paramGroups
+  match methodParams with
+  | [] -> generator []
+  | _  -> let paramGroups =  gen_param_groups message methodParams in
+    List.iter generator paramGroups
 
 and gen_exposed_method_overloads out_chan cls message =
   let generator = fun x -> gen_exposed_method out_chan cls message x in
@@ -647,7 +647,7 @@ and gen_exposed_method out_chan cls msg curParams =
   let callParams = exposed_call_params msg classname curParams in
   let publishInfo = get_published_info_message msg cls in
   let deprecatedInfo = get_deprecated_info_message msg in
-  let deprecatedAttribute = get_deprecated_attribute msg in 
+  let deprecatedAttribute = get_deprecated_attribute msg in
   let deprecatedInfoString = (if deprecatedInfo = "" then "" else "\n        /// "^deprecatedInfo) in
   let deprecatedAttributeString = (if deprecatedAttribute = "" then "" else "\n        "^deprecatedAttribute) in
   print "
@@ -661,11 +661,11 @@ and gen_exposed_method out_chan cls msg curParams =
     msg.msg_doc (if publishInfo = "" then "" else "\n        /// "^publishInfo)
     deprecatedInfoString
     paramsDoc
-    deprecatedAttributeString 
-    exposed_ret_type  
+    deprecatedAttributeString
+    exposed_ret_type
     msg.msg_name paramSignature
     (convert_from_proxy_opt (sprintf "session.proxy.%s(%s).parse()" proxyMsgName callParams) msg.msg_result);
-  if msg.msg_async then 
+  if msg.msg_async then
     print "
         /// <summary>
         /// %s%s%s
@@ -683,24 +683,24 @@ and gen_exposed_method out_chan cls msg curParams =
 
 and returns_xenobject msg =
   match msg.msg_result with
-    |  Some (Record r, _) -> true
-    |  _ -> false
+  |  Some (Record r, _) -> true
+  |  _ -> false
 
 and get_params_doc msg classname params =
   let sessionDoc = "\n        /// <param name=\"session\">The session</param>" in
   let refDoc =  if is_method_static msg then ""
-                else if (msg.msg_name = "get_by_permission") then
-                  sprintf "\n        /// <param name=\"_%s\">The opaque_ref of the given permission</param>" (String.lowercase classname)
-                else if (msg.msg_name = "revert") then
-                  sprintf "\n        /// <param name=\"_%s\">The opaque_ref of the given snapshotted state</param>" (String.lowercase classname)
-                else sprintf "\n        /// <param name=\"_%s\">The opaque_ref of the given %s</param>"
-                     (String.lowercase classname) (String.lowercase classname) in
+    else if (msg.msg_name = "get_by_permission") then
+      sprintf "\n        /// <param name=\"_%s\">The opaque_ref of the given permission</param>" (String.lowercase classname)
+    else if (msg.msg_name = "revert") then
+      sprintf "\n        /// <param name=\"_%s\">The opaque_ref of the given snapshotted state</param>" (String.lowercase classname)
+    else sprintf "\n        /// <param name=\"_%s\">The opaque_ref of the given %s</param>"
+        (String.lowercase classname) (String.lowercase classname) in
   String.concat "" (sessionDoc::(refDoc::(List.map (fun x -> get_param_doc msg x) params)))
 
 and get_param_doc msg x =
   let publishInfo = get_published_info_param msg x in
-    sprintf "\n        /// <param name=\"_%s\">%s%s</param>" (String.lowercase x.param_name) x.param_doc
-      (if publishInfo = "" then "" else " "^publishInfo)
+  sprintf "\n        /// <param name=\"_%s\">%s%s</param>" (String.lowercase x.param_name) x.param_doc
+    (if publishInfo = "" then "" else " "^publishInfo)
 
 and exposed_params message classname params =
   let exposedParams = List.map exposed_param params in
@@ -709,7 +709,7 @@ and exposed_params message classname params =
   String.concat ", " ("Session session"::exposedParams)
 
 and exposed_param p =
-      sprintf "%s _%s" (internal_type p.param_type) (String.lowercase p.param_name)
+  sprintf "%s _%s" (internal_type p.param_type) (String.lowercase p.param_name)
 
 and exposed_call_params message classname params =
   let exposedParams = List.map exposed_call_param params in
@@ -731,21 +731,21 @@ and gen_save_changes out_chan exposed_class_name messages contents =
   let length = List.length fields2 + List.length readonlyFieldsWithSetters in
   let print format = fprintf out_chan format in
   if length == 0 then
-    print 
-"              throw new InvalidOperationException(\"This type has no read/write properties\");"
-  else 
-    (List.iter (gen_save_changes_to_field out_chan exposed_class_name) fields2;
-    (* Generate calls to any set_ methods *)
-     List.iter (gen_save_changes_to_field out_chan exposed_class_name) readonlyFieldsWithSetters;
     print
-"
+      "              throw new InvalidOperationException(\"This type has no read/write properties\");"
+  else
+    (List.iter (gen_save_changes_to_field out_chan exposed_class_name) fields2;
+     (* Generate calls to any set_ methods *)
+     List.iter (gen_save_changes_to_field out_chan exposed_class_name) readonlyFieldsWithSetters;
+     print
+       "
                 return null;";)
 
 
 and flatten_content content =
   match content with
-      Field fr -> [ fr ]
-    | Namespace (_, c) -> List.flatten (List.map flatten_content c)
+    Field fr -> [ fr ]
+  | Namespace (_, c) -> List.flatten (List.map flatten_content c)
 
 
 and gen_save_changes_to_field out_chan exposed_class_name fr =
@@ -755,8 +755,8 @@ and gen_save_changes_to_field out_chan exposed_class_name fr =
     (* Use AreEqual2 - see CA-19220 *)
     sprintf "Helper.AreEqual2(_%s, server._%s)" full_name_fr full_name_fr
   in
-    print
-"                if (!%s)
+  print
+    "                if (!%s)
                 {
                     %s.set_%s(session, opaqueRef, _%s);
                 }
@@ -772,24 +772,24 @@ and ctor_call classname =
 
 and gen_exposed_field out_chan cls content =
   match content with
-    | Field fr ->
-        let print format = fprintf out_chan format in
-        let full_name_fr = full_name fr in
-        let comp = sprintf "!Helper.AreEqual(value, _%s)" full_name_fr in
-        let publishInfo = get_published_info_field fr cls in
-        
-          print "
+  | Field fr ->
+    let print format = fprintf out_chan format in
+    let full_name_fr = full_name fr in
+    let comp = sprintf "!Helper.AreEqual(value, _%s)" full_name_fr in
+    let publishInfo = get_published_info_field fr cls in
+
+    print "
         /// <summary>
         /// %s%s
         /// </summary>
         public virtual %s %s
         {
             get { return _%s; }" fr.field_description
-  (if publishInfo = "" then "" else "\n        /// "^publishInfo) 
-  (exposed_type fr.ty) full_name_fr full_name_fr;
+      (if publishInfo = "" then "" else "\n        /// "^publishInfo)
+      (exposed_type fr.ty) full_name_fr full_name_fr;
 
-              print
-"
+    print
+      "
             set
             {
                 if (%s)
@@ -801,24 +801,24 @@ and gen_exposed_field out_chan cls content =
             }
         }" comp full_name_fr full_name_fr;
 
-              print "
+    print "
         private %s _%s;\n" (exposed_type fr.ty) full_name_fr
 
-	  | Namespace (_, c) -> List.iter (gen_exposed_field out_chan cls) c
+  | Namespace (_, c) -> List.iter (gen_exposed_field out_chan cls) c
 
 (* ------------------- category: proxy classes *)
 
 and gen_proxy() =
   let out_chan = open_out (Filename.concat destdir "Proxy.cs")
   in
-    finally (fun () -> gen_proxy' out_chan)
-            (fun () -> close_out out_chan)
+  finally (fun () -> gen_proxy' out_chan)
+    (fun () -> close_out out_chan)
 
 
 and gen_proxy' out_chan =
   let print format = fprintf out_chan format in
 
-(* NB the Event methods below must be manually written out since the class is hand-written not autogenerated *)
+  (* NB the Event methods below must be manually written out since the class is hand-written not autogenerated *)
   print "%s
 
 using System;
@@ -868,14 +868,14 @@ namespace XenAPI
   List.iter
     (fun x -> if proxy_generated x then gen_proxy_for_class out_chan x) classes;
   print
-"    }
+    "    }
 
 ";
 
   List.iter (fun x -> if proxy_generated x then gen_proxyclass out_chan x) classes;
 
   print
-"}
+    "}
 "
 
 
@@ -900,8 +900,8 @@ and gen_proxy_method out_chan classname message params =
         Response<%s>
         %s(%s);
 " classname message.msg_name
-  proxy_ret_type 
-  proxy_msg_name proxyParams;
+    proxy_ret_type
+    proxy_msg_name proxyParams;
 
   if message.msg_async then
     print "
@@ -909,7 +909,7 @@ and gen_proxy_method out_chan classname message params =
         Response<string>
         async_%s(%s);
 " classname message.msg_name
-  proxy_msg_name proxyParams;
+      proxy_msg_name proxyParams;
 
 
 and proxy_params message classname params =
@@ -925,35 +925,35 @@ and proxy_param p =
 
 and ctor_fields fields =
   List.filter (function { DT.qualifier = (DT.StaticRO | DT.RW) } -> true | _ -> false) fields
-    
+
 
 and gen_proxyclass out_chan {name=classname; contents=contents} =
   let print format = fprintf out_chan format in
 
   print
-"    [XmlRpcMissingMapping(MappingAction.Ignore)]
+    "    [XmlRpcMissingMapping(MappingAction.Ignore)]
     public class Proxy_%s
     {
 " (exposed_class_name classname);
 
   List.iter (gen_proxy_field out_chan) contents;
 
-print
-"    }
+  print
+    "    }
 
 "
 
 
 and gen_proxy_field out_chan content =
   match content with
-      Field fr ->
-        let print format = fprintf out_chan format in
+    Field fr ->
+    let print format = fprintf out_chan format in
 
-          print
-"        public %s %s;
+    print
+      "        public %s %s;
 " (proxy_type fr.ty) (full_name fr)
 
-    | Namespace (_, c) -> List.iter (gen_proxy_field out_chan) c
+  | Namespace (_, c) -> List.iter (gen_proxy_field out_chan) c
 
 
 (* ------------------- category: enums *)
@@ -961,12 +961,12 @@ and gen_proxy_field out_chan content =
 
 and gen_enum = function
   | Enum(name, contents) ->
-      if not (List.mem name !api_members) then
-        api_members := name::!api_members;
-      let out_chan = open_out (Filename.concat destdir (name ^ ".cs"))
-      in
-        finally (fun () -> gen_enum' name contents out_chan)
-                (fun () -> close_out out_chan)
+    if not (List.mem name !api_members) then
+      api_members := name::!api_members;
+    let out_chan = open_out (Filename.concat destdir (name ^ ".cs"))
+    in
+    finally (fun () -> gen_enum' name contents out_chan)
+      (fun () -> close_out out_chan)
   | _ -> assert false
 
 
@@ -1002,8 +1002,8 @@ namespace XenAPI
 " name name;
 
   List.iter (fun (wire, _) ->
-    print "                case %s.%s:\n                    return \"%s\";\n" name (enum_of_wire wire) wire
-  ) contents;
+      print "                case %s.%s:\n                    return \"%s\";\n" name (enum_of_wire wire) wire
+    ) contents;
 
   print "                default:
                     return \"unknown\";
@@ -1023,7 +1023,7 @@ and has_unknown_entry contents =
     | x :: xs -> if String.lowercase (fst x) = "unknown" then true else f xs
     | []      -> false
   in
-    f contents
+  f contents
 
 
 (* ------------------- category: maps *)
@@ -1033,7 +1033,7 @@ and gen_maps() =
   let out_chan = open_out (Filename.concat destdir "Maps.cs")
   in
   finally (fun () -> gen_maps' out_chan)
-          (fun () -> close_out out_chan)
+    (fun () -> close_out out_chan)
 
 
 and gen_maps' out_chan =
@@ -1054,21 +1054,21 @@ namespace XenAPI
 
   TypeSet.iter (gen_map_conversion out_chan) !maps;
 
-print "
+  print "
     }
 }
 "
 
 and gen_map_conversion out_chan = function
     Map(l, r) ->
-      let print format = fprintf out_chan format in
-      let el = exposed_type l in
-      let el_literal = exposed_type_as_literal l in
-      let er = exposed_type r in
-      let er_literal = exposed_type_as_literal r in
+    let print format = fprintf out_chan format in
+    let el = exposed_type l in
+    let el_literal = exposed_type_as_literal l in
+    let er = exposed_type r in
+    let er_literal = exposed_type_as_literal r in
 
-      print
-"        internal static Dictionary<%s, %s>
+    print
+      "        internal static Dictionary<%s, %s>
         convert_from_proxy_%s_%s(Object o)
         {
             Hashtable table = (Hashtable)o;
@@ -1116,13 +1116,13 @@ and gen_map_conversion out_chan = function
         }
 
 " el er (sanitise_function_name el_literal) (sanitise_function_name er_literal)
-  el er el er
-  el (convert_from_proxy_never_null_string "key" l)
-  er (convert_from_proxy_hashtable_value "table[key]" r)
-  (sanitise_function_name el_literal) (sanitise_function_name er_literal) el er el
-  (proxy_type l) (convert_to_proxy "key" l)
-  (proxy_type r) (convert_to_proxy "table[key]" r)
-(***)
+      el er el er
+      el (convert_from_proxy_never_null_string "key" l)
+      er (convert_from_proxy_hashtable_value "table[key]" r)
+      (sanitise_function_name el_literal) (sanitise_function_name er_literal) el er el
+      (proxy_type l) (convert_to_proxy "key" l)
+      (proxy_type r) (convert_to_proxy "table[key]" r)
+  (***)
 
   | _ -> assert false
 
@@ -1161,12 +1161,12 @@ and exposed_type = function
   | Ref name                -> sprintf "XenRef<%s>" (exposed_class_name name)
   | Set(Ref name)           -> sprintf "List<XenRef<%s>>" (exposed_class_name name)
   | Set(Enum(name, _) as x) -> enums := TypeSet.add x !enums;
-                               sprintf "List<%s>" name
+    sprintf "List<%s>" name
   | Set(Int)                -> "long[]"
   | Set(String)             -> "string[]"
   | Enum(name, _) as x      -> enums := TypeSet.add x !enums; name
   | Map(u, v)               -> sprintf "Dictionary<%s, %s>" (exposed_type u)
-                                                            (exposed_type v)
+                                 (exposed_type v)
   | Record name             -> exposed_class_name name
   | Set(Record name)        -> sprintf "List<%s>" (exposed_class_name name)
   | _                       -> assert false
@@ -1211,36 +1211,36 @@ and convert_from_proxy_never_null_string thing ty = (* for when 'thing' is never
 
 and convert_from_hashtable fname ty =
   let field = sprintf "\"%s\"" fname in
-    match ty with
-      | DateTime            -> sprintf "Marshalling.ParseDateTime(table, %s)" field
-      | Bool                -> sprintf "Marshalling.ParseBool(table, %s)" field
-      | Float               -> sprintf "Marshalling.ParseDouble(table, %s)" field
-      | Int                 -> sprintf "Marshalling.ParseLong(table, %s)" field
-      | Ref name            -> sprintf "Marshalling.ParseRef<%s>(table, %s)" (exposed_class_name name) field
-      | String              -> sprintf "Marshalling.ParseString(table, %s)" field
-      | Set(String)         -> sprintf "Marshalling.ParseStringArray(table, %s)" field
-      | Set(Ref name)       -> sprintf "Marshalling.ParseSetRef<%s>(table, %s)" (exposed_class_name name) field
-      | Set(Enum(name, _))  -> sprintf "Helper.StringArrayToEnumList<%s>(Marshalling.ParseStringArray(table, %s))" name field
-      | Enum(name, _)       -> sprintf "(%s)Helper.EnumParseDefault(typeof(%s), Marshalling.ParseString(table, %s))" name name field
-      | Map(Ref name, Record _) -> sprintf "Marshalling.ParseMapRefRecord<%s, Proxy_%s>(table, %s)" (exposed_class_name name) (exposed_class_name name) field
-      | Map(u, v) as x      ->
-          maps := TypeSet.add x !maps;
-           sprintf "%s(Marshalling.ParseHashTable(table, %s))"
-	         (sanitise_function_name (sprintf "Maps.convert_from_proxy_%s_%s" (exposed_type_as_literal u) (exposed_type_as_literal v))) field
-      | Record name         -> 
-          sprintf "new %s((Proxy_%s)table[%s])"
-            (exposed_class_name name) (exposed_class_name name) field
-      | Set(Record name)    -> 
-          sprintf "Helper.Proxy_%sArrayTo%sList(Marshalling.ParseStringArray(%s))"
-            (exposed_class_name name) (exposed_class_name name) field
-      | Set(Int)            -> sprintf "Marshalling.ParseLongArray(table, %s)" field
-      | _                   -> assert false 
+  match ty with
+  | DateTime            -> sprintf "Marshalling.ParseDateTime(table, %s)" field
+  | Bool                -> sprintf "Marshalling.ParseBool(table, %s)" field
+  | Float               -> sprintf "Marshalling.ParseDouble(table, %s)" field
+  | Int                 -> sprintf "Marshalling.ParseLong(table, %s)" field
+  | Ref name            -> sprintf "Marshalling.ParseRef<%s>(table, %s)" (exposed_class_name name) field
+  | String              -> sprintf "Marshalling.ParseString(table, %s)" field
+  | Set(String)         -> sprintf "Marshalling.ParseStringArray(table, %s)" field
+  | Set(Ref name)       -> sprintf "Marshalling.ParseSetRef<%s>(table, %s)" (exposed_class_name name) field
+  | Set(Enum(name, _))  -> sprintf "Helper.StringArrayToEnumList<%s>(Marshalling.ParseStringArray(table, %s))" name field
+  | Enum(name, _)       -> sprintf "(%s)Helper.EnumParseDefault(typeof(%s), Marshalling.ParseString(table, %s))" name name field
+  | Map(Ref name, Record _) -> sprintf "Marshalling.ParseMapRefRecord<%s, Proxy_%s>(table, %s)" (exposed_class_name name) (exposed_class_name name) field
+  | Map(u, v) as x      ->
+    maps := TypeSet.add x !maps;
+    sprintf "%s(Marshalling.ParseHashTable(table, %s))"
+      (sanitise_function_name (sprintf "Maps.convert_from_proxy_%s_%s" (exposed_type_as_literal u) (exposed_type_as_literal v))) field
+  | Record name         ->
+    sprintf "new %s((Proxy_%s)table[%s])"
+      (exposed_class_name name) (exposed_class_name name) field
+  | Set(Record name)    ->
+    sprintf "Helper.Proxy_%sArrayTo%sList(Marshalling.ParseStringArray(%s))"
+      (exposed_class_name name) (exposed_class_name name) field
+  | Set(Int)            -> sprintf "Marshalling.ParseLongArray(table, %s)" field
+  | _                   -> assert false
 
 and sanitise_function_name name =
   String.implode (List.filter (fun c -> c<>'>' && c<>'<' && c<>',' && c<>' ') (String.explode name))
 
 and simple_convert_from_proxy thing ty =
-   match ty with
+  match ty with
   | DateTime            -> thing
   | Int                 -> sprintf "long.Parse((string)%s)" thing
   | Bool                -> sprintf "(bool)%s" thing
@@ -1248,30 +1248,30 @@ and simple_convert_from_proxy thing ty =
   | Ref name            -> sprintf "XenRef<%s>.Create(%s)" (exposed_class_name name) thing
   | String              -> sprintf "(string)%s" thing
   | Set(String)         -> sprintf "(string [])%s" thing
-  | Set(Ref name)       -> sprintf "XenRef<%s>.Create(%s)" (exposed_class_name name) thing 
+  | Set(Ref name)       -> sprintf "XenRef<%s>.Create(%s)" (exposed_class_name name) thing
   | Set(Enum(name, _))  -> sprintf "Helper.StringArrayToEnumList<%s>(%s)" name thing
   | Enum(name, _)       -> sprintf "(%s)Helper.EnumParseDefault(typeof(%s), (string)%s)" name name thing
   | Map(Ref name, Record _) -> sprintf "XenRef<%s>.Create<Proxy_%s>(%s)" (exposed_class_name name) (exposed_class_name name) thing
-  | Map(u, v) as x      -> 
-      maps := TypeSet.add x !maps;
-      sprintf "%s(%s)"
+  | Map(u, v) as x      ->
+    maps := TypeSet.add x !maps;
+    sprintf "%s(%s)"
       (sanitise_function_name (sprintf "Maps.convert_from_proxy_%s_%s" (exposed_type_as_literal u) (exposed_type_as_literal v))) thing
-  | Record name         -> 
-      sprintf "new %s((Proxy_%s)%s)"
+  | Record name         ->
+    sprintf "new %s((Proxy_%s)%s)"
       (exposed_class_name name) (exposed_class_name name) thing
-  | Set(Record name)    -> 
-      sprintf "Helper.Proxy_%sArrayTo%sList(%s)" 
+  | Set(Record name)    ->
+    sprintf "Helper.Proxy_%sArrayTo%sList(%s)"
       (exposed_class_name name) (exposed_class_name name) thing
   | Set(Int)            ->
-      sprintf "Helper.StringArrayToLongArray(%s)" thing
-  | _                   -> assert false 
+    sprintf "Helper.StringArrayToLongArray(%s)" thing
+  | _                   -> assert false
 
 
 and convert_to_proxy thing ty = (*function*)
   match ty with
   | DateTime            -> thing
   | Int                 -> sprintf "%s.ToString()" thing
-  | Bool                
+  | Bool
   | Float               -> thing
   | Ref _               -> sprintf "(%s != null) ? %s : \"\"" thing thing
   | String              -> sprintf "(%s != null) ? %s : \"\"" thing thing
@@ -1281,8 +1281,8 @@ and convert_to_proxy thing ty = (*function*)
   | Set (Int) -> sprintf "(%s != null) ? Helper.LongArrayToStringArray(%s) : new string[] {}" thing thing
   | Set(Enum(_, _))  -> sprintf "(%s != null) ? Helper.ObjectListToStringArray(%s) : new string[] {}" thing thing
   | Map(u, v) as x      -> maps := TypeSet.add x !maps;
-                           sprintf "%s(%s)"
-                           (sanitise_function_name (sprintf "Maps.convert_to_proxy_%s_%s" (exposed_type_as_literal u) (exposed_type_as_literal v))) thing
+    sprintf "%s(%s)"
+      (sanitise_function_name (sprintf "Maps.convert_to_proxy_%s_%s" (exposed_type_as_literal u) (exposed_type_as_literal v))) thing
   | Record name         -> sprintf "%s.ToProxy()" thing
 
   | _                   -> assert false
@@ -1310,33 +1310,33 @@ and full_description field =
 
 and is_readonly field =
   match field.qualifier with
-      RW   -> "false"
-    | _    -> "true"
+    RW   -> "false"
+  | _    -> "true"
 
 
 and is_static_readonly field =
   match field.qualifier with
-      StaticRO     -> "true"
-    | DynamicRO    -> "false"
-    | _            -> "false"
+    StaticRO     -> "true"
+  | DynamicRO    -> "false"
+  | _            -> "false"
 
 and i18n_header out_chan =
   let print format = fprintf out_chan format in
-    print
-"<?xml version=\"1.0\" encoding=\"utf-8\"?>
+  print
+    "<?xml version=\"1.0\" encoding=\"utf-8\"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name=\"resmimetype\">text/microsoft-resx</resheader>
     <resheader name=\"version\">2.0</resheader>
@@ -1351,36 +1351,36 @@ and i18n_header out_chan =
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of \"resheader\" rows that contain simple 
+
+    There are any number of \"resheader\" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -1445,30 +1445,30 @@ and i18n_header out_chan =
 "
 and i18n_footer out_chan =
   let print format = fprintf out_chan format in
-    print
-"</root>\n"
+  print
+    "</root>\n"
 and gen_i18n_errors () =
   Friendly_error_names.parse_sr_xml sr_xml;
   Friendly_error_names.parse_resx resx_file;
   let out_chan = open_out (Filename.concat destdir "FriendlyErrorNames.resx")
   in
-    finally (fun () ->
-               i18n_header out_chan;
-               List.iter (gen_i18n_error_field out_chan)
-                 (Friendly_error_names.friendly_names_all Datamodel.errors);
-               i18n_footer out_chan)
-            (fun () -> close_out out_chan)
+  finally (fun () ->
+      i18n_header out_chan;
+      List.iter (gen_i18n_error_field out_chan)
+        (Friendly_error_names.friendly_names_all Datamodel.errors);
+      i18n_footer out_chan)
+    (fun () -> close_out out_chan)
 
 
 and gen_i18n_error_field out_chan (error, desc) =
   let print format = fprintf out_chan format in
-    (* Note that we can't use Xml.to_string for the whole block, because
-       we need the output to be whitespace-identical to what Visual Studio
-       would produce.  We need to use it for the inner <value> though, to
-       get the escaping right. *)
-    print "  <data name=\"%s\" xml:space=\"preserve\">\n    %s\n  </data>\n"
-      error
-      (Xml.to_string (Xml.Element("value", [], [(Xml.PCData desc)])))
+  (* Note that we can't use Xml.to_string for the whole block, because
+     we need the output to be whitespace-identical to what Visual Studio
+     would produce.  We need to use it for the inner <value> though, to
+     get the escaping right. *)
+  print "  <data name=\"%s\" xml:space=\"preserve\">\n    %s\n  </data>\n"
+    error
+    (Xml.to_string (Xml.Element("value", [], [(Xml.PCData desc)])))
 
 let populate_releases ()=
   render_file ("ApiVersion.mustache", "ApiVersion.cs") json_releases templdir destdir

--- a/powershell/common_functions.ml
+++ b/powershell/common_functions.ml
@@ -1,19 +1,19 @@
 (*
  * Copyright (c) Citrix Systems, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  *   1) Redistributions of source code must retain the above copyright
  *      notice, this list of conditions and the following disclaimer.
- * 
+ *
  *   2) Redistributions in binary form must reproduce the above
  *      copyright notice, this list of conditions and the following
  *      disclaimer in the documentation and/or other materials
  *      provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -36,37 +36,37 @@ open Datamodel
 open Datamodel_types
 open Datamodel_utils
 open Dm_api
-  
+
 module DU = Datamodel_utils
-  
+
 let rec pascal_case_ s =
   let ss = String.split '_' s in
   let ss' = List.map transform ss in
   match ss' with
-    | [] -> ""
-    | h::tl -> 
-      let h' = if String.length h > 1 then
+  | [] -> ""
+  | h::tl ->
+    let h' = if String.length h > 1 then
         let sndchar = String.sub h 1 1 in
         if sndchar = String.uppercase sndchar then h
-          else String.capitalize h
-      else String.uncapitalize h 
-      in
-      h' ^ (String.concat "" tl)
+        else String.capitalize h
+      else String.uncapitalize h
+    in
+    h' ^ (String.concat "" tl)
 
-and pascal_case s = 
+and pascal_case s =
   let str = pascal_case_ s in
-    if(String.length str > 3 
-      && ((String.lowercase (String.sub str 0 3)) = "set"
-       || (String.lowercase (String.sub str 0 3)) = "get")) 
-    then String.sub str 3 ((String.length str) - 3)
-    else str
+  if(String.length str > 3
+     && ((String.lowercase (String.sub str 0 3)) = "set"
+         || (String.lowercase (String.sub str 0 3)) = "get"))
+  then String.sub str 3 ((String.length str) - 3)
+  else str
 
 and transform s =
   String.capitalize (String.uncapitalize s)
 
 and lower_and_underscore_first s =
-  sprintf "_%s%s" 
-    (String.uncapitalize (String.sub s 0 1)) 
+  sprintf "_%s%s"
+    (String.uncapitalize (String.sub s 0 1))
     (String.sub s 1 ((String.length s) - 1))
 
 and ocaml_class_to_csharp_property classname =
@@ -85,34 +85,34 @@ and ocaml_field_to_csharp_local_var field =
 
 and ocaml_field_to_csharp_property field =
   ocaml_class_to_csharp_property (full_name field)
-     
+
 and exposed_class_name classname =
   match String.lowercase(classname) with
-    | "vm"  -> "VM"
-    | "vdi" -> "VDI"
-    | "vbd" -> "VBD"
-    | "pbd" -> "PBD"
-    | "sr"  -> "SR"
-    | "vif" -> "VIF"
-    | "pif" -> "PIF"
-    | "url" -> "Url_"
-    |  _     -> String.capitalize classname
+  | "vm"  -> "VM"
+  | "vdi" -> "VDI"
+  | "vbd" -> "VBD"
+  | "pbd" -> "PBD"
+  | "sr"  -> "SR"
+  | "vif" -> "VIF"
+  | "pif" -> "PIF"
+  | "url" -> "Url_"
+  |  _     -> String.capitalize classname
 
 and qualified_class_name classname =
-    "XenAPI."^(exposed_class_name classname)  
+  "XenAPI."^(exposed_class_name classname)
 
 and type_default ty =
   match ty with
-    | Int         -> ""
-    | String      -> ""
-    | Float       -> ""
-    | Bool        -> ""
-    | Enum _      -> ""
-    | Record r    -> ""
-    | Ref r       -> ""
-    | Map(u, v)   -> " = new Hashtable()"
-    | Set(String) -> " = new string[0]"
-    | _           -> sprintf " = new %s()"(exposed_type ty) 
+  | Int         -> ""
+  | String      -> ""
+  | Float       -> ""
+  | Bool        -> ""
+  | Enum _      -> ""
+  | Record r    -> ""
+  | Ref r       -> ""
+  | Map(u, v)   -> " = new Hashtable()"
+  | Set(String) -> " = new string[0]"
+  | _           -> sprintf " = new %s()"(exposed_type ty)
 
 and escaped = function
   | "params" -> "paramz"
@@ -126,14 +126,14 @@ and full_description field =
 
 and is_readonly field =
   match field.qualifier with
-    | RW   -> "false"
-    | _    -> "true"
+  | RW   -> "false"
+  | _    -> "true"
 
 and is_static_readonly field =
   match field.qualifier with
-    | StaticRO     -> "true"
-    | DynamicRO    -> "false"
-    | _            -> "false"
+  | StaticRO     -> "true"
+  | DynamicRO    -> "false"
+  | _            -> "false"
 
 and exposed_type_opt = function
   | Some (typ, _) -> exposed_type typ
@@ -152,19 +152,19 @@ and exposed_type = function
   | Set(String)             -> "string[]"
   | Enum(name, _)           -> name
   | Map(u, v)               -> sprintf "Dictionary<%s, %s>" (exposed_type u)
-                                                            (exposed_type v)
+                                 (exposed_type v)
   | Record name             -> qualified_class_name name
   | Set(Record name)        -> sprintf "List<%s>" (qualified_class_name name)
   | _                       -> assert false
 
 and obj_internal_type = function
-    | Ref x         -> sprintf "XenRef<%s>" (qualified_class_name x)
-    | Set(Ref x)    -> sprintf "List<XenRef<%s>>" (qualified_class_name x)
-    | Map(u, v)     -> "Hashtable"
-    | Record x      -> qualified_class_name x
-    | Set(Record x) -> sprintf "List<%s>" (qualified_class_name x)
-    | x             -> exposed_type x
-  
+  | Ref x         -> sprintf "XenRef<%s>" (qualified_class_name x)
+  | Set(Ref x)    -> sprintf "List<XenRef<%s>>" (qualified_class_name x)
+  | Map(u, v)     -> "Hashtable"
+  | Record x      -> qualified_class_name x
+  | Set(Record x) -> sprintf "List<%s>" (qualified_class_name x)
+  | x             -> exposed_type x
+
 and escape_angles str =
   String.escaped ~rules:[('<' , "&lt;"); ('>' , "&gt;")] str
 
@@ -172,32 +172,32 @@ and is_invoke message =
   message.msg_tag = Custom
 
 and is_setter message =
-  (String.length message.msg_name >= 3) 
-    && (String.sub message.msg_name 0 3) = "set" 
+  (String.length message.msg_name >= 3)
+  && (String.sub message.msg_name 0 3) = "set"
 
 and is_getter message =
-  (String.length message.msg_name >= 3) 
-    && (String.sub message.msg_name 0 3) = "get"
+  (String.length message.msg_name >= 3)
+  && (String.sub message.msg_name 0 3) = "get"
 
 and is_adder message =
-  (String.length message.msg_name >= 3) 
-    && (String.sub message.msg_name 0 3) = "add"
-  
+  (String.length message.msg_name >= 3)
+  && (String.sub message.msg_name 0 3) = "add"
+
 and is_remover message =
-  (String.length message.msg_name >= 6) 
-    && (String.sub message.msg_name 0 6) = "remove"
- 
+  (String.length message.msg_name >= 6)
+  && (String.sub message.msg_name 0 6) = "remove"
+
 and is_constructor message =
- (message.msg_tag = (FromObject Make) || message.msg_name = "create")
+  (message.msg_tag = (FromObject Make) || message.msg_name = "create")
 
 and is_real_constructor message =
- message.msg_tag = (FromObject Make)
+  message.msg_tag = (FromObject Make)
 
 and is_destructor message =
   (message.msg_tag = (FromObject Delete) || message.msg_name = "destroy")
-  
 
-(* Some adders/removers are just prefixed by Add or RemoveFrom 
+
+(* Some adders/removers are just prefixed by Add or RemoveFrom
    and some are prefixed by AddTo or RemoveFrom *)
 and cut_msg_name message_name fn_type =
   let name_len = String.length message_name in
@@ -214,16 +214,16 @@ and cut_msg_name message_name fn_type =
     begin
       if (name_len > 10) && (String.sub message_name 0 10) = "RemoveFrom" then
         String.sub message_name 10 (name_len - 10)
-      else if (name_len > 6) && (String.sub message_name 0 6) = "Remove" then 
+      else if (name_len > 6) && (String.sub message_name 0 6) = "Remove" then
         String.sub message_name 6 (name_len - 6)
       else
         message_name (* case of a destructor *)
     end
   else
     message_name
-      
+
 (* True if an object has a uuid (and therefore should have a get_by_uuid message *)
-and has_uuid x = 
+and has_uuid x =
   let all_fields = DU.fields_of_obj x in
   List.filter (fun fld -> fld.full_name = [ "uuid" ]) all_fields <> []
 
@@ -232,15 +232,15 @@ and has_name x =
 
 and get_http_action_verb name meth =
   let parts = String.split '_' name in
-    if (List.exists (fun x -> x = "import") parts) then "Import"
-    else if (List.exists (fun x -> x = "export") parts) then "Export"
-    else if (List.exists (fun x -> x = "get") parts) then "Receive"
-    else if (List.exists (fun x -> x = "put") parts) then "Send"
-    else
-      match meth with
-      | Get -> "Receive"
-      | Put -> "Send"
-      | _   -> assert false
+  if (List.exists (fun x -> x = "import") parts) then "Import"
+  else if (List.exists (fun x -> x = "export") parts) then "Export"
+  else if (List.exists (fun x -> x = "get") parts) then "Receive"
+  else if (List.exists (fun x -> x = "put") parts) then "Send"
+  else
+    match meth with
+    | Get -> "Receive"
+    | Put -> "Send"
+    | _   -> assert false
 
 and get_common_verb_category verb =
   match verb with
@@ -260,8 +260,8 @@ and get_http_action_stem name =
 
 and trim_http_action_stem x =
   match x with
-  | "get"  
-  | "put" 
+  | "get"
+  | "put"
   | "import"
   | "export"
   | "download"

--- a/powershell/gen_powershell_binding.ml
+++ b/powershell/gen_powershell_binding.ml
@@ -1,19 +1,19 @@
 (*
  * Copyright (c) Citrix Systems, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  *   1) Redistributions of source code must retain the above copyright
  *      notice, this list of conditions and the following disclaimer.
- * 
+ *
  *   2) Redistributions in binary form must reproduce the above
  *      copyright notice, this list of conditions and the following
  *      disclaimer in the documentation and/or other materials
  *      provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -61,23 +61,23 @@ let _ =
 let destdir = !destdir'
 
 let api =
-	Datamodel_utils.named_self := true;
-	let obj_filter _ = true in
-	let field_filter field =
-		(not field.internal_only) && (List.mem "closed" field.release.internal)
-	in
-	let message_filter msg = 
-		Datamodel_utils.on_client_side msg &&
+  Datamodel_utils.named_self := true;
+  let obj_filter _ = true in
+  let field_filter field =
+    (not field.internal_only) && (List.mem "closed" field.release.internal)
+  in
+  let message_filter msg =
+    Datamodel_utils.on_client_side msg &&
     (not msg.msg_hide_from_docs) &&
     (not (List.mem msg.msg_name ["get_by_name_label"; "get_by_uuid";
                                  "get"; "get_all" ; "get_all_records";
                                  "get_all_records_where"; "get_record";])) &&
-		(msg.msg_tag <> (FromObject GetAllRecords)) &&
-		(List.mem "closed" msg.msg_release.internal)
-	in
-	filter obj_filter field_filter message_filter
-		(Datamodel_utils.add_implicit_messages ~document_order:false
-			(filter obj_filter field_filter message_filter Datamodel.all_api))
+    (msg.msg_tag <> (FromObject GetAllRecords)) &&
+    (List.mem "closed" msg.msg_release.internal)
+  in
+  filter obj_filter field_filter message_filter
+    (Datamodel_utils.add_implicit_messages ~document_order:false
+       (filter obj_filter field_filter message_filter Datamodel.all_api))
 
 let classes = objects_of_api api
 let maps = ref TypeSet.empty
@@ -120,36 +120,36 @@ namespace Citrix.XenServer.Commands
         #region Cmdlet Parameters
 %s%s
         #endregion
-        
+
         #region Cmdlet Methods
-        
+
         protected override void ProcessRecord()
         {
             GetSession();
 %s
             RunApiCall(() => %s);
         }
-        
+
         #endregion
     }
 }\n" Licence.bsd_two_clause
-     verbCategory commonVerb stem (gen_should_process_http_decl meth)
-     commonVerb stem
-     (gen_progress_tracker meth)
-     (gen_arg_params args)
-     (gen_should_process_http meth uri)
-     (gen_http_action_call action)
-in
-  write_file (sprintf "%s-Xen%s.cs" commonVerb stem) content
+        verbCategory commonVerb stem (gen_should_process_http_decl meth)
+        commonVerb stem
+        (gen_progress_tracker meth)
+        (gen_arg_params args)
+        (gen_should_process_http meth uri)
+        (gen_http_action_call action)
+    in
+    write_file (sprintf "%s-Xen%s.cs" commonVerb stem) content
 
 and gen_should_process_http_decl meth =
-    match meth with
+  match meth with
   | Put -> ", SupportsShouldProcess = true"
   | Get   -> ", SupportsShouldProcess = false"
   | _   -> assert false
 
 and gen_should_process_http meth uri =
-    match meth with
+  match meth with
   | Put -> sprintf "
             if (!ShouldProcess(\"%s\"))
                 return;\n" uri
@@ -169,7 +169,7 @@ and gen_arg_params args =
   match args with
   | []     -> ""
   | hd::tl -> sprintf "%s%s" (gen_arg_param hd) (gen_arg_params tl)
-    
+
 and gen_arg_param = function
   | String_query_arg x -> sprintf "
         [Parameter%s]
@@ -181,9 +181,9 @@ and gen_arg_param = function
   | Int64_query_arg x -> sprintf "
         [Parameter]
         public long %s { get; set; }\n" (pascal_case_ x)
-  | Bool_query_arg x -> 
-      let y = if x = "host" then "is_host" else x in
-      sprintf "
+  | Bool_query_arg x ->
+    let y = if x = "host" then "is_host" else x in
+    sprintf "
         [Parameter]
         public bool %s { get; set; }\n" (pascal_case_ y)
   | Varargs_query_arg -> sprintf "
@@ -195,25 +195,25 @@ and gen_arg_param = function
 
 and gen_http_action_call (name, (meth, _, _, args, _, _)) =
   let progressTracker = match meth with
-                        | Get -> "DataCopiedDelegate"
-                        | Put -> "ProgressDelegate"
-                        | _   -> assert false in
+    | Get -> "DataCopiedDelegate"
+    | Put -> "ProgressDelegate"
+    | _   -> assert false in
   sprintf "XenAPI.HTTP_actions.%s(%s,
                 CancellingDelegate, TimeoutMs, XenHost, Proxy, Path, TaskRef,
                 session.opaque_ref%s)"
     name progressTracker (gen_call_arg_params args)
 
 and gen_call_arg_params args =
-    match args with
+  match args with
   | []     -> ""
   | hd::tl -> sprintf "%s%s" (gen_call_arg_param hd) (gen_call_arg_params tl)
 
 and gen_call_arg_param = function
   | String_query_arg x -> sprintf ", %s" (pascal_case_ x)
   | Int64_query_arg x -> sprintf ", %s" (pascal_case_ x)
-  | Bool_query_arg x -> 
-      let y = if x = "host" then "is_host" else x in
-      sprintf ", %s" (pascal_case_ y)
+  | Bool_query_arg x ->
+    let y = if x = "host" then "is_host" else x in
+    sprintf ", %s" (pascal_case_ y)
   | Varargs_query_arg -> sprintf ", Args"
 
 
@@ -261,21 +261,21 @@ namespace Citrix.XenServer.Commands
 
 and print_converters classes =
   match classes with
-    | []       -> ""
-    | hd::tl -> sprintf "
+  | []       -> ""
+  | hd::tl -> sprintf "
             %s %s = XenObject as %s;
             if (%s != null)
             {
                 WriteObject(new XenRef<%s>(%s));
                 return;
             }%s"
-                    (qualified_class_name hd.name)
-                    (ocaml_class_to_csharp_local_var hd.name)
-                    (qualified_class_name hd.name)
-                    (ocaml_class_to_csharp_local_var hd.name)
-                    (qualified_class_name hd.name)
-                    (ocaml_class_to_csharp_local_var hd.name)
-                    (print_converters tl)
+                (qualified_class_name hd.name)
+                (ocaml_class_to_csharp_local_var hd.name)
+                (qualified_class_name hd.name)
+                (ocaml_class_to_csharp_local_var hd.name)
+                (qualified_class_name hd.name)
+                (ocaml_class_to_csharp_local_var hd.name)
+                (print_converters tl)
 
 (*************************)
 (* Autogenerated cmdlets *)
@@ -285,37 +285,37 @@ and gen_binding obj =
   match obj with
     {name=classname; description = description; messages=messages;
      contents=contents; gen_constructor_destructor=gen_const_dest} ->
-   let partNew = List.partition (fun x -> is_constructor x) messages in
-   let constructors = fst partNew in
-   let partDest = List.partition (fun x -> is_destructor x) (snd partNew) in
-   let destructors = fst partDest in
-   let partRem = List.partition (fun x -> is_remover x) (snd partDest) in
-   let removers = fst partRem in
-   let partAdd = List.partition (fun x -> is_adder x) (snd partRem) in
-   let adders = fst partAdd in
-   let partSet = List.partition (fun x -> is_setter x) (snd partAdd) in
-   let setters = fst partSet in 
-   let partGet = List.partition (fun x -> is_getter x) (snd partSet) in
-   let getters = fst partGet in
-   let invokers = List.filter (fun x -> is_invoke x) (snd partGet) in
-   let stem = ocaml_class_to_csharp_class classname in
-   begin
-     write_file (sprintf "Get-Xen%s.cs" stem) (gen_class obj classname);
-     if ((List.length constructors) > 0) then
-       write_file (sprintf "New-Xen%s.cs" stem) (gen_constructor obj classname constructors);
-     if ((List.length destructors) > 0) then
-       write_file (sprintf "Remove-Xen%s.cs" stem) (gen_destructor obj classname destructors);
-     if ((List.length removers) > 0) then
-       write_file (sprintf "Remove-Xen%sProperty.cs" stem) (gen_remover obj classname removers);
-     if ((List.length adders) > 0) then
-       write_file (sprintf "Add-Xen%s.cs" stem) (gen_adder obj classname adders);
-     if ((List.length setters) > 0) then
-       write_file (sprintf "Set-Xen%s.cs" stem) (gen_setter obj classname setters);
-     if ((List.length getters) > 0) then
-       write_file (sprintf "Get-Xen%sProperty.cs" stem) (gen_getter obj classname getters);
-     if ((List.length invokers) > 0) then
-       write_file (sprintf "Invoke-Xen%s.cs" stem) (gen_invoker obj classname invokers);
-   end
+    let partNew = List.partition (fun x -> is_constructor x) messages in
+    let constructors = fst partNew in
+    let partDest = List.partition (fun x -> is_destructor x) (snd partNew) in
+    let destructors = fst partDest in
+    let partRem = List.partition (fun x -> is_remover x) (snd partDest) in
+    let removers = fst partRem in
+    let partAdd = List.partition (fun x -> is_adder x) (snd partRem) in
+    let adders = fst partAdd in
+    let partSet = List.partition (fun x -> is_setter x) (snd partAdd) in
+    let setters = fst partSet in
+    let partGet = List.partition (fun x -> is_getter x) (snd partSet) in
+    let getters = fst partGet in
+    let invokers = List.filter (fun x -> is_invoke x) (snd partGet) in
+    let stem = ocaml_class_to_csharp_class classname in
+    begin
+      write_file (sprintf "Get-Xen%s.cs" stem) (gen_class obj classname);
+      if ((List.length constructors) > 0) then
+        write_file (sprintf "New-Xen%s.cs" stem) (gen_constructor obj classname constructors);
+      if ((List.length destructors) > 0) then
+        write_file (sprintf "Remove-Xen%s.cs" stem) (gen_destructor obj classname destructors);
+      if ((List.length removers) > 0) then
+        write_file (sprintf "Remove-Xen%sProperty.cs" stem) (gen_remover obj classname removers);
+      if ((List.length adders) > 0) then
+        write_file (sprintf "Add-Xen%s.cs" stem) (gen_adder obj classname adders);
+      if ((List.length setters) > 0) then
+        write_file (sprintf "Set-Xen%s.cs" stem) (gen_setter obj classname setters);
+      if ((List.length getters) > 0) then
+        write_file (sprintf "Get-Xen%sProperty.cs" stem) (gen_getter obj classname getters);
+      if ((List.length invokers) > 0) then
+        write_file (sprintf "Invoke-Xen%s.cs" stem) (gen_invoker obj classname invokers);
+    end
 
 and write_file filename format =
   let out_chan = open_out (Filename.concat destdir filename) in
@@ -326,7 +326,7 @@ and write_file filename format =
 (*********************************)
 (* Print function for Get-XenFoo *)
 (*********************************)
-	
+
 and gen_class obj classname =
   (print_header_class classname)^
   (print_parameters_class obj classname)^
@@ -355,18 +355,18 @@ namespace Citrix.XenServer.Commands
     (ocaml_class_to_csharp_class classname)
     (qualified_class_name classname)
     (ocaml_class_to_csharp_class classname)
-    
+
 and print_parameters_class obj classname =
   sprintf
-"        #region Cmdlet Parameters
+    "        #region Cmdlet Parameters
 %s
         #endregion\n"
     (print_xenobject_params obj classname false false true)
 
 and get_process_record_method_if_exists classname classType has_uuid has_name =
-    if not (List.mem classname expose_get_all_messages_for)
-    then  sprintf ""
-    else  sprintf "
+  if not (List.mem classname expose_get_all_messages_for)
+  then  sprintf ""
+  else  sprintf "
 
         protected override void ProcessRecord()
         {
@@ -406,9 +406,9 @@ and get_process_record_method_if_exists classname classType has_uuid has_name =
             UpdateSessions();
         }
     "
-    classType
-    classType
-    (if has_name then sprintf "
+      classType
+      classType
+      (if has_name then sprintf "
             else if (Name != null)
             {
                 var options = WildcardOptions.IgnoreCase
@@ -422,8 +422,8 @@ and get_process_record_method_if_exists classname classType has_uuid has_name =
                         results.Add(record.Value);
                 }
             }"
-    else "")
-    (if has_uuid then sprintf "
+       else "")
+      (if has_uuid then sprintf "
             else if (Uuid != Guid.Empty)
             {
                 foreach (var record in records)
@@ -433,8 +433,8 @@ and get_process_record_method_if_exists classname classType has_uuid has_name =
                         break;
                     }
             }"
-    else "")
-    (exposed_class_name classname)    
+       else "")
+      (exposed_class_name classname)
 
 
 
@@ -442,27 +442,27 @@ and get_process_record_method_if_exists classname classType has_uuid has_name =
 and print_methods_class classname has_uuid has_name =
   let classType = (qualified_class_name classname) in
   sprintf "
-        #region Cmdlet Methods%s        
+        #region Cmdlet Methods%s
         #endregion
     }
 }\n"
 
     (get_process_record_method_if_exists classname classType has_uuid has_name)
 
-    
+
 
 
 (*********************************)
 (* Print function for New-XenFoo *)
 (*********************************)
-  
+
 and gen_constructor obj classname messages =
   match messages with
-    | []  -> ""
-    | [x] -> (print_header_constructor x obj classname)^
-             (print_params_constructor x obj classname)^
-             (print_methods_constructor x obj classname)
-    | _   -> assert false
+  | []  -> ""
+  | [x] -> (print_header_constructor x obj classname)^
+           (print_params_constructor x obj classname)^
+           (print_methods_constructor x obj classname)
+  | _   -> assert false
 
 and print_header_constructor message obj classname =
   sprintf "%s
@@ -483,7 +483,7 @@ namespace Citrix.XenServer.Commands
     public class NewXen%sCommand : XenServerCmdlet
     {"
     Licence.bsd_two_clause
-    (ocaml_class_to_csharp_class classname) 
+    (ocaml_class_to_csharp_class classname)
     (qualified_class_name classname)
     (if message.msg_async then "
     [OutputType(typeof(XenAPI.Task))]"
@@ -493,9 +493,9 @@ namespace Citrix.XenServer.Commands
 and print_params_constructor message obj classname =
   sprintf "
         #region Cmdlet Parameters
-        
+
         [Parameter]
-        public SwitchParameter PassThru { get; set; }      
+        public SwitchParameter PassThru { get; set; }
 
         [Parameter(ParameterSetName = \"Hashtable\", Mandatory = true)]
         public Hashtable HashTable { get; set; }
@@ -508,7 +508,7 @@ and print_params_constructor message obj classname =
     (if is_real_constructor message then gen_fields (DU.fields_of_obj obj)
      else gen_constructor_params message.msg_params)
     (if message.msg_async then
-        "
+       "
         protected override bool GenerateAsyncParam
         {
             get { return true; }
@@ -517,19 +517,19 @@ and print_params_constructor message obj classname =
 
 and gen_constructor_params params =
   match params with
-    |  []     -> ""
-    |  hd::tl -> sprintf"%s\n%s" 
-                   (gen_constructor_param hd.param_name hd.param_type ["Fields"])
-                   (gen_constructor_params tl)
+  |  []     -> ""
+  |  hd::tl -> sprintf"%s\n%s"
+                 (gen_constructor_param hd.param_name hd.param_type ["Fields"])
+                 (gen_constructor_params tl)
 
 and gen_fields fields =
   match fields with
-    |  []     -> ""
-    |  hd::tl -> match hd.qualifier with
-                   |  DynamicRO -> (gen_fields tl)
-                   |  _         -> sprintf "%s\n%s"
-       (gen_constructor_param (full_name hd) hd.ty ["Fields"])
-       (gen_fields tl)
+  |  []     -> ""
+  |  hd::tl -> match hd.qualifier with
+    |  DynamicRO -> (gen_fields tl)
+    |  _         -> sprintf "%s\n%s"
+                      (gen_constructor_param (full_name hd) hd.ty ["Fields"])
+                      (gen_fields tl)
 
 and gen_constructor_param paramName paramType paramsets =
   let publicName = ocaml_class_to_csharp_property paramName in
@@ -538,10 +538,10 @@ and gen_constructor_param paramName paramType paramsets =
   else sprintf "
         %s
         public %s %s { get; set; }" (print_parameter_sets paramsets)
-         (obj_internal_type paramType) publicName
+      (obj_internal_type paramType) publicName
 
 and print_methods_constructor message obj classname =
-  sprintf "    
+  sprintf "
         #region Cmdlet Methods
 
         protected override void ProcessRecord()
@@ -550,24 +550,24 @@ and print_methods_constructor message obj classname =
             RunApiCall(()=>
             {%s
             });
-            
+
             UpdateSessions();
         }
 
         #endregion
    }
-}\n" 
+}\n"
     (if is_real_constructor message then gen_make_record message obj classname
-      else gen_make_fields message obj classname)
+     else gen_make_fields message obj classname)
     (gen_shouldprocess "New" message classname)
     (gen_csharp_api_call message classname "New" "passthru")
 
 and create_param_parse param paramName =
   match param.param_type with
-    | Ref name -> sprintf "
+  | Ref name -> sprintf "
             string %s = %s.opaque_ref;\n"
-                    (String.lowercase param.param_name) paramName
-    | _ -> ""
+                  (String.lowercase param.param_name) paramName
+  | _ -> ""
 
 and gen_make_record message obj classname =
   sprintf "
@@ -578,29 +578,29 @@ and gen_make_record message obj classname =
             else if (Record == null)
             {
                 Record = new %s(HashTable);
-            }\n" 
+            }\n"
     (qualified_class_name classname)
     (gen_record_fields (DU.fields_of_obj obj))
     (qualified_class_name classname)
 
 and gen_record_fields fields =
   match fields with
-    | [] -> ""
-    | h::tl -> match h.qualifier with
-                 |  DynamicRO -> (gen_record_fields tl)
-                 |  _ -> sprintf "
+  | [] -> ""
+  | h::tl -> match h.qualifier with
+    |  DynamicRO -> (gen_record_fields tl)
+    |  _ -> sprintf "
                 %s%s" (gen_record_field h) (gen_record_fields tl)
 
 and gen_record_field field =
   match field.ty with
-    |  Ref r     -> sprintf "Record.%s = %s == null ? null : new %s(%s.opaque_ref);"
-                      (full_name field) (ocaml_field_to_csharp_property field)
-                      (obj_internal_type field.ty) (ocaml_field_to_csharp_property field)
-    |  Map(u, v) -> sprintf "Record.%s = CommonCmdletFunctions.ConvertHashTableToDictionary<%s, %s>(%s);"
-                      (full_name field) (exposed_type u) (exposed_type v)
-                      (pascal_case (full_name field))
-    |  _         -> sprintf "Record.%s = %s;" 
-                      (full_name field) (ocaml_field_to_csharp_property field)
+  |  Ref r     -> sprintf "Record.%s = %s == null ? null : new %s(%s.opaque_ref);"
+                    (full_name field) (ocaml_field_to_csharp_property field)
+                    (obj_internal_type field.ty) (ocaml_field_to_csharp_property field)
+  |  Map(u, v) -> sprintf "Record.%s = CommonCmdletFunctions.ConvertHashTableToDictionary<%s, %s>(%s);"
+                    (full_name field) (exposed_type u) (exposed_type v)
+                    (pascal_case (full_name field))
+  |  _         -> sprintf "Record.%s = %s;"
+                    (full_name field) (ocaml_field_to_csharp_property field)
 
 and gen_make_fields message obj classname =
   sprintf "
@@ -609,84 +609,84 @@ and gen_make_fields message obj classname =
             }
             else if (HashTable != null)
             {%s
-            }" 
+            }"
     (explode_record_fields message (DU.fields_of_obj obj))
     (explode_hashtable_fields message (DU.fields_of_obj obj))
 
 and explode_record_fields message fields =
   let print_map tl hd =
     sprintf "
-                %s = CommonCmdletFunctions.ConvertDictionaryToHashtable(Record.%s);%s" 
-      (exposed_class_name (pascal_case (full_name hd))) 
+                %s = CommonCmdletFunctions.ConvertDictionaryToHashtable(Record.%s);%s"
+      (exposed_class_name (pascal_case (full_name hd)))
       (full_name hd)
       (explode_record_fields message tl) in
   let print_record tl hd =
     sprintf "
-                %s = Record.%s;%s" 
-      (exposed_class_name (pascal_case (full_name hd))) 
+                %s = Record.%s;%s"
+      (exposed_class_name (pascal_case (full_name hd)))
       (full_name hd)
       (explode_record_fields message tl) in
   match fields with
-    |  []     -> ""
-    |  hd::tl -> 
-        if List.exists (fun x -> (full_name hd) = x.param_name) message.msg_params then
-          match hd.ty with
-            | Map(u, v) -> print_map tl hd     
-            | _ -> print_record tl hd            
-        else explode_record_fields message tl
+  |  []     -> ""
+  |  hd::tl ->
+    if List.exists (fun x -> (full_name hd) = x.param_name) message.msg_params then
+      match hd.ty with
+      | Map(u, v) -> print_map tl hd
+      | _ -> print_record tl hd
+    else explode_record_fields message tl
 
-and explode_hashtable_fields message fields =  
+and explode_hashtable_fields message fields =
   match fields with
-    |  []     -> ""
-    |  hd::tl -> 
-        if List.exists (fun x -> (full_name hd) = x.param_name) message.msg_params then
-          sprintf "
-                %s = %s;%s" 
-            (ocaml_class_to_csharp_property (full_name hd)) 
-            (convert_from_hashtable (full_name hd) hd.ty)
-            (explode_hashtable_fields message tl)
-        else
-          explode_hashtable_fields message tl
+  |  []     -> ""
+  |  hd::tl ->
+    if List.exists (fun x -> (full_name hd) = x.param_name) message.msg_params then
+      sprintf "
+                %s = %s;%s"
+        (ocaml_class_to_csharp_property (full_name hd))
+        (convert_from_hashtable (full_name hd) hd.ty)
+        (explode_hashtable_fields message tl)
+    else
+      explode_hashtable_fields message tl
 
 and convert_from_hashtable fname ty =
   let field = sprintf "\"%s\"" fname in
-    match ty with
-      | DateTime             -> sprintf "Marshalling.ParseDateTime(HashTable, %s)" field
-      | Bool                 -> sprintf "Marshalling.ParseBool(HashTable, %s)" field
-      | Float                -> sprintf "Marshalling.ParseDouble(HashTable, %s)" field
-      | Int                  -> sprintf "Marshalling.ParseLong(HashTable, %s)" field
-      | Ref name             -> sprintf "Marshalling.ParseRef<%s>(HashTable, %s)"
-                                  (exposed_class_name name) field
-      | String               -> sprintf "Marshalling.ParseString(HashTable, %s)" field
-      | Set(String)          -> sprintf "Marshalling.ParseStringArray(HashTable, %s)" field
-      | Set(Ref x)           -> sprintf "Marshalling.ParseSetRef<%s>(HashTable, %s)"
-                                  (exposed_class_name x) field
-      | Set(Enum(x, _))      -> sprintf "Helper.StringArrayToEnumList<%s>(Marshalling.ParseStringArray(HashTable, %s))" x field
-      | Enum(x, _)           -> sprintf "(%s)CommonCmdletFunctions.EnumParseDefault(typeof(%s), Marshalling.ParseString(HashTable, %s))"
-                                 x x field
-      | Map(Ref x, Record _) -> sprintf "Marshalling.ParseMapRefRecord<%s, Proxy_%s>(HashTable, %s)"
-                                     (exposed_class_name x) (exposed_class_name x) field
-      | Map(u, v) as x       -> maps := TypeSet.add x !maps;
-                                sprintf "(Marshalling.ParseHashTable(HashTable, %s))" field
-      | Record name          -> sprintf "new %s((Proxy_%s)HashTable[%s])"
-                                  (exposed_class_name name)
-                                  (exposed_class_name name) field
-      | Set(Record name)     -> sprintf "Helper.Proxy_%sArrayTo%sList(Marshalling.ParseStringArray(%s))"
-                                  (exposed_class_name name)
-                                  (exposed_class_name name) field
-      | _                   -> assert false 
+  match ty with
+  | DateTime             -> sprintf "Marshalling.ParseDateTime(HashTable, %s)" field
+  | Bool                 -> sprintf "Marshalling.ParseBool(HashTable, %s)" field
+  | Float                -> sprintf "Marshalling.ParseDouble(HashTable, %s)" field
+  | Int                  -> sprintf "Marshalling.ParseLong(HashTable, %s)" field
+  | Ref name             -> sprintf "Marshalling.ParseRef<%s>(HashTable, %s)"
+                              (exposed_class_name name) field
+  | String               -> sprintf "Marshalling.ParseString(HashTable, %s)" field
+  | Set(String)          -> sprintf "Marshalling.ParseStringArray(HashTable, %s)" field
+  | Set(Ref x)           -> sprintf "Marshalling.ParseSetRef<%s>(HashTable, %s)"
+                              (exposed_class_name x) field
+  | Set(Enum(x, _))      -> sprintf "Helper.StringArrayToEnumList<%s>(Marshalling.ParseStringArray(HashTable, %s))" x field
+  | Enum(x, _)           -> sprintf "(%s)CommonCmdletFunctions.EnumParseDefault(typeof(%s), Marshalling.ParseString(HashTable, %s))"
+                              x x field
+  | Map(Ref x, Record _) -> sprintf "Marshalling.ParseMapRefRecord<%s, Proxy_%s>(HashTable, %s)"
+                              (exposed_class_name x) (exposed_class_name x) field
+  | Map(u, v) as x       -> maps := TypeSet.add x !maps;
+    sprintf "(Marshalling.ParseHashTable(HashTable, %s))" field
+  | Record name          -> sprintf "new %s((Proxy_%s)HashTable[%s])"
+                              (exposed_class_name name)
+                              (exposed_class_name name) field
+  | Set(Record name)     -> sprintf "Helper.Proxy_%sArrayTo%sList(Marshalling.ParseStringArray(%s))"
+                              (exposed_class_name name)
+                              (exposed_class_name name) field
+  | _                   -> assert false
 
 
 
 (************************************)
 (* Print function for Remove-XenFoo *)
 (************************************)
-    
+
 and gen_destructor obj classname messages =
   let cut_message_name = fun x-> cut_msg_name (pascal_case x.msg_name) "Remove" in
   let asyncMessages = List.map cut_message_name (List.filter (fun x -> x.msg_async) messages) in
-    sprintf
-"%s
+  sprintf
+    "%s
 
 using System;
 using System.Collections;
@@ -704,66 +704,66 @@ namespace Citrix.XenServer.Commands
     public class RemoveXen%s : XenServerCmdlet
     {
         #region Cmdlet Parameters
-        
+
         [Parameter]
         public SwitchParameter PassThru { get; set; }
 %s%s
         #endregion
 
         #region Cmdlet Methods
-        
+
         protected override void ProcessRecord()
         {
             GetSession();
 
             string %s = Parse%s();
-            
+
             %s
 
             UpdateSessions();
         }
-        
+
         #endregion
-    
+
         #region Private Methods
 %s%s
         #endregion
     }
 }\n"
-      Licence.bsd_two_clause
-      (ocaml_class_to_csharp_class classname)
-      (qualified_class_name classname)
-      (if (List.length asyncMessages) > 0 then "
+    Licence.bsd_two_clause
+    (ocaml_class_to_csharp_class classname)
+    (qualified_class_name classname)
+    (if (List.length asyncMessages) > 0 then "
     [OutputType(typeof(XenAPI.Task))]" else "")
-      (ocaml_class_to_csharp_class classname)
-      (print_xenobject_params obj classname true true true)
-      (if (List.length asyncMessages) > 0 then sprintf "
+    (ocaml_class_to_csharp_class classname)
+    (print_xenobject_params obj classname true true true)
+    (if (List.length asyncMessages) > 0 then sprintf "
         protected override bool GenerateAsyncParam
         {
             get { return true; }
         }\n" else "")
-      (ocaml_class_to_csharp_local_var classname) (ocaml_class_to_csharp_property classname)
-      (print_cmdlet_methods_remover classname messages)
-      (print_parse_xenobject_private_method obj classname true)
-      (print_process_record_private_methods classname messages "Remove" "asyncpassthru")
+    (ocaml_class_to_csharp_local_var classname) (ocaml_class_to_csharp_property classname)
+    (print_cmdlet_methods_remover classname messages)
+    (print_parse_xenobject_private_method obj classname true)
+    (print_process_record_private_methods classname messages "Remove" "asyncpassthru")
 
 and print_cmdlet_methods_remover classname messages =
   let localVar = (ocaml_class_to_csharp_local_var classname) in
   let cut_message_name x = cut_msg_name (pascal_case x.msg_name) "Remove" in
   match messages with
-    | [x] -> sprintf "ProcessRecord%s(%s);" (cut_message_name x) localVar
-    | _   -> assert false
+  | [x] -> sprintf "ProcessRecord%s(%s);" (cut_message_name x) localVar
+  | _   -> assert false
 
 
 (*****************************************)
 (* Print function for Remove-XenFoo -Bar *)
 (*****************************************)
-    
+
 and gen_remover obj classname messages =
   let cut_message_name = fun x-> cut_msg_name (pascal_case x.msg_name) "Remove" in
   let asyncMessages = List.map cut_message_name (List.filter (fun x -> x.msg_async) messages) in
-    sprintf
-"%s
+  sprintf
+    "%s
 
 using System;
 using System.Collections;
@@ -780,60 +780,60 @@ namespace Citrix.XenServer.Commands
     public class RemoveXen%sProperty : XenServerCmdlet
     {
         #region Cmdlet Parameters
-        
+
         [Parameter]
         public SwitchParameter PassThru { get; set; }
 %s%s%s
         #endregion
 
         #region Cmdlet Methods
-        
+
         protected override void ProcessRecord()
         {
             GetSession();
-            
+
             string %s = Parse%s();
-            
+
             %s
-            
+
             %s
-            
+
             UpdateSessions();
         }
-        
+
         #endregion
-    
+
         #region Private Methods
 %s%s
         #endregion
     }
 }\n"
-      Licence.bsd_two_clause
-      (ocaml_class_to_csharp_class classname)
-      (qualified_class_name classname)
-      (if (List.length asyncMessages) > 0 then "
+    Licence.bsd_two_clause
+    (ocaml_class_to_csharp_class classname)
+    (qualified_class_name classname)
+    (if (List.length asyncMessages) > 0 then "
     [OutputType(typeof(XenAPI.Task))]"
-       else "")
-      (ocaml_class_to_csharp_class classname)
-      (print_xenobject_params obj classname true true true)
-      (print_async_param asyncMessages)
-      (gen_message_as_param classname "Remove" messages)
-      (ocaml_class_to_csharp_local_var classname) (ocaml_class_to_csharp_property classname)
-      (print_cmdlet_methods classname messages "Remove")
-      (gen_passthru classname)
-      (print_parse_xenobject_private_method obj classname true)
-      (print_process_record_private_methods classname messages "Remove" "")
+     else "")
+    (ocaml_class_to_csharp_class classname)
+    (print_xenobject_params obj classname true true true)
+    (print_async_param asyncMessages)
+    (gen_message_as_param classname "Remove" messages)
+    (ocaml_class_to_csharp_local_var classname) (ocaml_class_to_csharp_property classname)
+    (print_cmdlet_methods classname messages "Remove")
+    (gen_passthru classname)
+    (print_parse_xenobject_private_method obj classname true)
+    (print_process_record_private_methods classname messages "Remove" "")
 
 
 (**************************************)
 (* Print function for Set-XenFoo -Bar *)
 (**************************************)
-    
+
 and gen_setter obj classname messages =
   let cut_message_name = fun x-> cut_msg_name (pascal_case x.msg_name) "Set" in
   let asyncMessages = List.map cut_message_name (List.filter (fun x -> x.msg_async) messages) in
-    sprintf
-"%s
+  sprintf
+    "%s
 
 using System;
 using System.Collections;
@@ -851,60 +851,60 @@ namespace Citrix.XenServer.Commands
     public class SetXen%s : XenServerCmdlet
     {
         #region Cmdlet Parameters
-        
+
         [Parameter]
         public SwitchParameter PassThru { get; set; }
 %s%s%s
         #endregion
 
         #region Cmdlet Methods
-        
+
         protected override void ProcessRecord()
         {
             GetSession();
-            
+
             string %s = Parse%s();
-            
+
             %s
-            
+
             %s
-        
+
             UpdateSessions();
         }
-        
+
         #endregion
-    
+
         #region Private Methods
 %s%s
         #endregion
     }
 }\n"
-      Licence.bsd_two_clause
-      (ocaml_class_to_csharp_class classname)
-      (qualified_class_name classname)
-      (if (List.length asyncMessages) > 0 then "
+    Licence.bsd_two_clause
+    (ocaml_class_to_csharp_class classname)
+    (qualified_class_name classname)
+    (if (List.length asyncMessages) > 0 then "
     [OutputType(typeof(XenAPI.Task))]"
-       else "")
-      (ocaml_class_to_csharp_class classname)
-      (print_xenobject_params obj classname true true true)
-      (print_async_param asyncMessages)
-      (gen_message_as_param classname "Set" messages)
-      (ocaml_class_to_csharp_local_var classname) (ocaml_class_to_csharp_property classname)
-      (print_cmdlet_methods classname messages "Set")
-      (gen_passthru classname)
-      (print_parse_xenobject_private_method obj classname true)
-      (print_process_record_private_methods classname messages "Set" "")  
+     else "")
+    (ocaml_class_to_csharp_class classname)
+    (print_xenobject_params obj classname true true true)
+    (print_async_param asyncMessages)
+    (gen_message_as_param classname "Set" messages)
+    (ocaml_class_to_csharp_local_var classname) (ocaml_class_to_csharp_property classname)
+    (print_cmdlet_methods classname messages "Set")
+    (gen_passthru classname)
+    (print_parse_xenobject_private_method obj classname true)
+    (print_process_record_private_methods classname messages "Set" "")
 
 
 (**************************************)
 (* Print function for Add-XenFoo -Bar *)
 (**************************************)
-    
+
 and gen_adder obj classname messages =
   let cut_message_name = fun x-> cut_msg_name (pascal_case x.msg_name) "Add" in
   let asyncMessages = List.map cut_message_name (List.filter (fun x -> x.msg_async) messages) in
-    sprintf
-"%s
+  sprintf
+    "%s
 
 using System;
 using System.Collections;
@@ -922,49 +922,49 @@ namespace Citrix.XenServer.Commands
     public class AddXen%s : XenServerCmdlet
     {
         #region Cmdlet Parameters
-        
+
         [Parameter]
         public SwitchParameter PassThru { get; set; }
 %s%s%s
         #endregion
 
         #region Cmdlet Methods
-        
+
         protected override void ProcessRecord()
         {
             GetSession();
-            
+
             string %s = Parse%s();
-            
+
             %s
-            
+
             %s
-        
+
             UpdateSessions();
         }
-        
+
         #endregion
-    
+
         #region Private Methods
 %s%s
         #endregion
     }
 }\n"
-      Licence.bsd_two_clause
-      (ocaml_class_to_csharp_class classname)
-      (qualified_class_name classname)
-      (if (List.length asyncMessages) > 0 then "
+    Licence.bsd_two_clause
+    (ocaml_class_to_csharp_class classname)
+    (qualified_class_name classname)
+    (if (List.length asyncMessages) > 0 then "
     [OutputType(typeof(XenAPI.Task))]"
-       else "")
-      (ocaml_class_to_csharp_class classname)
-      (print_xenobject_params obj classname true true true)
-      (print_async_param asyncMessages)
-      (gen_message_as_param classname "Add" messages)
-      (ocaml_class_to_csharp_local_var classname) (ocaml_class_to_csharp_property classname)
-      (print_cmdlet_methods classname messages "Add")
-      (gen_passthru classname)
-      (print_parse_xenobject_private_method obj classname true)
-      (print_process_record_private_methods classname messages "Add" "")
+     else "")
+    (ocaml_class_to_csharp_class classname)
+    (print_xenobject_params obj classname true true true)
+    (print_async_param asyncMessages)
+    (gen_message_as_param classname "Add" messages)
+    (ocaml_class_to_csharp_local_var classname) (ocaml_class_to_csharp_property classname)
+    (print_cmdlet_methods classname messages "Add")
+    (gen_passthru classname)
+    (print_parse_xenobject_private_method obj classname true)
+    (print_process_record_private_methods classname messages "Add" "")
 
 
 (*****************************************)
@@ -972,9 +972,9 @@ namespace Citrix.XenServer.Commands
 (*****************************************)
 
 and gen_invoker obj classname messages =
-    let messagesWithParams = List.filter (is_message_with_dynamic_params classname) messages in
-    sprintf
-"%s
+  let messagesWithParams = List.filter (is_message_with_dynamic_params classname) messages in
+  sprintf
+    "%s
 
 using System;
 using System.Collections;
@@ -990,7 +990,7 @@ namespace Citrix.XenServer.Commands
     public class InvokeXen%s : XenServerCmdlet
     {
         #region Cmdlet Parameters
-        
+
         [Parameter]
         public SwitchParameter PassThru { get; set; }
 %s
@@ -1000,46 +1000,46 @@ namespace Citrix.XenServer.Commands
         #endregion
 %s
         #region Cmdlet Methods
-        
+
         protected override void ProcessRecord()
         {
             GetSession();
-            
+
             string %s = Parse%s();
-            
+
             switch (XenAction)
             {%s
             }
-            
+
             UpdateSessions();
         }
-        
+
         #endregion
-    
+
         #region Private Methods
 %s%s
         #endregion
     }
-    
+
     public enum Xen%sAction
     {%s
     }
 %s
 }\n"
-      Licence.bsd_two_clause
-      (ocaml_class_to_csharp_class classname)
-      (ocaml_class_to_csharp_class classname)
-      (print_xenobject_params obj classname true true true)
-      (ocaml_class_to_csharp_class classname)
-      (print_dynamic_generator classname "Action" "Invoke" messagesWithParams)
-      (ocaml_class_to_csharp_local_var classname) (ocaml_class_to_csharp_property classname)
-      (print_cmdlet_methods_dynamic classname messages "Action" "Invoke")
-      (print_parse_xenobject_private_method obj classname true)
-      (print_process_record_private_methods classname messages "Invoke" "passthru")
-      (ocaml_class_to_csharp_class classname)
-      (print_messages_as_enum "Invoke" messages)
-      (print_dynamic_params classname "Action" "Invoke" messagesWithParams)
- 
+    Licence.bsd_two_clause
+    (ocaml_class_to_csharp_class classname)
+    (ocaml_class_to_csharp_class classname)
+    (print_xenobject_params obj classname true true true)
+    (ocaml_class_to_csharp_class classname)
+    (print_dynamic_generator classname "Action" "Invoke" messagesWithParams)
+    (ocaml_class_to_csharp_local_var classname) (ocaml_class_to_csharp_property classname)
+    (print_cmdlet_methods_dynamic classname messages "Action" "Invoke")
+    (print_parse_xenobject_private_method obj classname true)
+    (print_process_record_private_methods classname messages "Invoke" "passthru")
+    (ocaml_class_to_csharp_class classname)
+    (print_messages_as_enum "Invoke" messages)
+    (print_dynamic_params classname "Action" "Invoke" messagesWithParams)
+
 
 (**********************************************)
 (* Print function for Get-XenFooProperty -Bar *)
@@ -1047,8 +1047,8 @@ namespace Citrix.XenServer.Commands
 
 and gen_getter obj classname messages =
   let messagesWithParams = List.filter (is_message_with_dynamic_params classname) messages in
-    sprintf
-"%s
+  sprintf
+    "%s
 
 using System;
 using System.Collections;
@@ -1067,76 +1067,76 @@ namespace Citrix.XenServer.Commands
 %s
         [Parameter(Mandatory = true)]
         public Xen%sProperty XenProperty { get; set; }
-        
+
         #endregion
 %s
         #region Cmdlet Methods
-        
+
         protected override void ProcessRecord()
         {
             GetSession();
-            
+
             string %s = Parse%s();
-            
+
             switch (XenProperty)
             {%s
             }
-            
+
             UpdateSessions();
         }
-        
+
         #endregion
-    
+
         #region Private Methods
 %s%s
         #endregion
     }
-    
+
     public enum Xen%sProperty
     {%s
     }
 %s
 }\n"
-      Licence.bsd_two_clause
-      (ocaml_class_to_csharp_class classname)
-      (ocaml_class_to_csharp_class classname)
-      (print_xenobject_params obj classname true true false)
-      (ocaml_class_to_csharp_class classname)
-      (print_dynamic_generator classname "Property" "Get" messagesWithParams)
-      (ocaml_class_to_csharp_local_var classname) (ocaml_class_to_csharp_property classname)
-      (print_cmdlet_methods_dynamic classname messages "Property" "Get")
-      (print_parse_xenobject_private_method obj classname false)
-      (print_process_record_private_methods classname messages "Get" "pipe")
-      (ocaml_class_to_csharp_class classname)
-      (print_messages_as_enum "Get" messages)
-      (print_dynamic_params classname "Property" "Get" messagesWithParams)
+    Licence.bsd_two_clause
+    (ocaml_class_to_csharp_class classname)
+    (ocaml_class_to_csharp_class classname)
+    (print_xenobject_params obj classname true true false)
+    (ocaml_class_to_csharp_class classname)
+    (print_dynamic_generator classname "Property" "Get" messagesWithParams)
+    (ocaml_class_to_csharp_local_var classname) (ocaml_class_to_csharp_property classname)
+    (print_cmdlet_methods_dynamic classname messages "Property" "Get")
+    (print_parse_xenobject_private_method obj classname false)
+    (print_process_record_private_methods classname messages "Get" "pipe")
+    (ocaml_class_to_csharp_class classname)
+    (print_messages_as_enum "Get" messages)
+    (print_dynamic_params classname "Property" "Get" messagesWithParams)
 
 and print_cmdlet_methods_dynamic classname messages enum commonVerb =
   let cut_message_name x = cut_msg_name (pascal_case x.msg_name) commonVerb in
   let localVar = (ocaml_class_to_csharp_local_var classname) in
   match messages with
-    | []     -> ""
-    | hd::tl -> sprintf "
+  | []     -> ""
+  | hd::tl -> sprintf "
                 case Xen%s%s.%s:
                     ProcessRecord%s(%s);
                     break;%s"
                 (ocaml_class_to_csharp_class classname) enum (cut_message_name hd)
                 (cut_message_name hd) localVar
-                (print_cmdlet_methods_dynamic classname tl enum commonVerb)  
+                (print_cmdlet_methods_dynamic classname tl enum commonVerb)
 
 and print_async_param_getter classname asyncMessages =
   let properties = List.map
-    (fun x -> sprintf "                    case Xen%sProperty.%s:"
-        (ocaml_class_to_csharp_class classname) x) asyncMessages in
+      (fun x -> sprintf "                    case Xen%sProperty.%s:"
+          (ocaml_class_to_csharp_class classname) x) asyncMessages in
   match asyncMessages with
-    | []          -> ""
-    | _           -> sprintf "
+  | []          -> ""
+  | _           -> sprintf "
         protected override bool GenerateAsyncParam
         {
             get
             {
                 switch (XenProperty)
-                { 
+                {
 %s
                         return true;
                     default:
@@ -1183,14 +1183,14 @@ and gen_passthru classname =
     (ocaml_class_to_csharp_local_var classname)
 
 and is_message_with_dynamic_params classname message =
-  let nonClassParams = List.filter (fun x -> not (is_class x classname)) message.msg_params in 
+  let nonClassParams = List.filter (fun x -> not (is_class x classname)) message.msg_params in
   if ((List.length nonClassParams) > 0) || message.msg_async then true
   else false
 
 and print_dynamic_generator classname enum commonVerb messagesWithParams =
   match messagesWithParams with
-    | [] -> ""
-    | _  -> sprintf "
+  | [] -> ""
+  | _  -> sprintf "
         public override object GetDynamicParameters()
         {
             switch (Xen%s)
@@ -1201,22 +1201,22 @@ and print_dynamic_generator classname enum commonVerb messagesWithParams =
         }\n" enum (print_messages_with_params classname enum commonVerb messagesWithParams)
 
 and print_messages_with_params classname enum commonVerb x =
-    match x with
-      | [] -> ""
-      | hd::tl -> sprintf "
+  match x with
+  | [] -> ""
+  | hd::tl -> sprintf "
                 case Xen%s%s.%s:
                     _context = new Xen%s%s%sDynamicParameters();
                     return _context;%s"
-                  (ocaml_class_to_csharp_class classname) enum
-                  (cut_msg_name (pascal_case hd.msg_name) commonVerb)
-                  (ocaml_class_to_csharp_class classname) enum
-                  (cut_msg_name (pascal_case hd.msg_name) commonVerb)
-                  (print_messages_with_params classname enum commonVerb tl)
+                (ocaml_class_to_csharp_class classname) enum
+                (cut_msg_name (pascal_case hd.msg_name) commonVerb)
+                (ocaml_class_to_csharp_class classname) enum
+                (cut_msg_name (pascal_case hd.msg_name) commonVerb)
+                (print_messages_with_params classname enum commonVerb tl)
 
 and print_dynamic_params classname enum commonVerb messagesWithParams =
   match messagesWithParams with
-    | []      -> ""
-    | hd::tl  -> sprintf "
+  | []      -> ""
+  | hd::tl  -> sprintf "
     public class Xen%s%s%sDynamicParameters : IXenServerDynamicParameter
     {%s%s
     }\n%s"
@@ -1231,16 +1231,16 @@ and print_dynamic_params classname enum commonVerb messagesWithParams =
 
 and print_dynamic_param_members classname params commonVerb =
   match params with
-    | []     -> ""
-    | hd::tl -> if is_class hd classname then
-                  print_dynamic_param_members classname tl commonVerb
-                else (
-        let publicProperty = 
-          (if commonVerb = "Invoke" && (List.mem (String.lowercase hd.param_name) ["name";"uuid"]) then
-            (ocaml_class_to_csharp_property hd.param_name)^"Param"
-           else ocaml_class_to_csharp_property hd.param_name) in
-        let theType = obj_internal_type hd.param_type in
-        sprintf "
+  | []     -> ""
+  | hd::tl -> if is_class hd classname then
+      print_dynamic_param_members classname tl commonVerb
+    else (
+      let publicProperty =
+        (if commonVerb = "Invoke" && (List.mem (String.lowercase hd.param_name) ["name";"uuid"]) then
+           (ocaml_class_to_csharp_property hd.param_name)^"Param"
+         else ocaml_class_to_csharp_property hd.param_name) in
+      let theType = obj_internal_type hd.param_type in
+      sprintf "
         [Parameter]
         public %s %s { get; set; }\n%s "
         theType publicProperty (print_dynamic_param_members classname tl commonVerb))
@@ -1248,19 +1248,19 @@ and print_dynamic_param_members classname params commonVerb =
 and print_messages_as_enum commonVerb messages =
   let cut_message_name = fun x-> cut_msg_name (pascal_case x.msg_name) commonVerb in
   match messages with
-    | []     -> ""
-    | [x]    -> sprintf "\n        %s" (cut_message_name x)
-    | hd::tl -> sprintf "\n        %s,%s" (cut_message_name hd) (print_messages_as_enum commonVerb tl)
+  | []     -> ""
+  | [x]    -> sprintf "\n        %s" (cut_message_name x)
+  | hd::tl -> sprintf "\n        %s,%s" (cut_message_name hd) (print_messages_as_enum commonVerb tl)
 
 
 and gen_message_as_param classname commonVerb messages =
-    match messages with
-      | []     -> ""
-      | hd::tl ->
-          let msgType = get_message_type hd classname commonVerb in
-          let cutMessageName = cut_msg_name (pascal_case hd.msg_name) commonVerb in
-          let msgName = if cutMessageName = "Host" then "XenHost" else cutMessageName in
-          sprintf "
+  match messages with
+  | []     -> ""
+  | hd::tl ->
+    let msgType = get_message_type hd classname commonVerb in
+    let cutMessageName = cut_msg_name (pascal_case hd.msg_name) commonVerb in
+    let msgName = if cutMessageName = "Host" then "XenHost" else cutMessageName in
+    sprintf "
         [Parameter]
         public %s %s
         {
@@ -1273,27 +1273,27 @@ and gen_message_as_param classname commonVerb messages =
         }
         private %s %s;
         private bool %sIsSpecified;\n%s"
-        msgType
-        msgName
-        (lower_and_underscore_first msgName)
-        (lower_and_underscore_first msgName)
-        (lower_and_underscore_first msgName)
-        msgType (lower_and_underscore_first msgName)
-        (lower_and_underscore_first msgName)
-        (gen_message_as_param classname commonVerb tl)
+      msgType
+      msgName
+      (lower_and_underscore_first msgName)
+      (lower_and_underscore_first msgName)
+      (lower_and_underscore_first msgName)
+      msgType (lower_and_underscore_first msgName)
+      (lower_and_underscore_first msgName)
+      (gen_message_as_param classname commonVerb tl)
 
 and print_cmdlet_methods classname messages commonVerb =
   let cut_message_name x = cut_msg_name (pascal_case x.msg_name) commonVerb in
-  let switch_name x = (if (cut_message_name x) = "Host" then "XenHost" else cut_message_name x) in  
+  let switch_name x = (if (cut_message_name x) = "Host" then "XenHost" else cut_message_name x) in
   let localVar = (ocaml_class_to_csharp_local_var classname) in
   match messages with
-    | []     -> ""
-    | [x]    -> sprintf "if (%sIsSpecified)
+  | []     -> ""
+  | [x]    -> sprintf "if (%sIsSpecified)
                 ProcessRecord%s(%s);"
                 (lower_and_underscore_first (switch_name x))
                 (cut_message_name x) localVar
-    | hd::tl -> sprintf
-           "if (%sIsSpecified)
+  | hd::tl -> sprintf
+                "if (%sIsSpecified)
                 ProcessRecord%s(%s);
             %s"
                 (lower_and_underscore_first (switch_name hd))
@@ -1305,26 +1305,26 @@ and print_xenobject_params obj classname mandatoryRef includeXenObject includeUu
   let publicName = ocaml_class_to_csharp_property classname in
   let privateName = lower_and_underscore_first publicName in
   sprintf "%s
-        
+
         [Parameter(ParameterSetName = \"Ref\"%s, ValueFromPipelineByPropertyName = true, Position = 0)]
         [Alias(\"opaque_ref\")]
         public XenRef<%s> Ref { get; set; }
 %s%s\n"
-      (if includeXenObject then print_param_xen_object (qualified_class_name classname) publicName privateName
-       else "")
-      (if mandatoryRef then ", Mandatory = true" else "")
-      (qualified_class_name classname)
-      (print_param_uuid ((has_uuid obj) && includeUuidAndName))
-      (print_param_name ((has_name obj) && includeUuidAndName))
+    (if includeXenObject then print_param_xen_object (qualified_class_name classname) publicName privateName
+     else "")
+    (if mandatoryRef then ", Mandatory = true" else "")
+    (qualified_class_name classname)
+    (print_param_uuid ((has_uuid obj) && includeUuidAndName))
+    (print_param_name ((has_name obj) && includeUuidAndName))
 
 and print_param_xen_object qualifiedClassName publicName privateName =
   sprintf "
         [Parameter(ParameterSetName = \"XenObject\", Mandatory = true, ValueFromPipeline = true, Position = 0)]
         public %s %s { get; set; }"
-        qualifiedClassName publicName
+    qualifiedClassName publicName
 
 and print_param_uuid hasUuid =
-  if hasUuid then sprintf "        
+  if hasUuid then sprintf "
         [Parameter(ParameterSetName = \"Uuid\", Mandatory = true, ValueFromPipelineByPropertyName = true, Position = 0)]
         public Guid Uuid { get; set; }\n"
   else sprintf ""
@@ -1338,8 +1338,8 @@ and print_param_name hasName =
 
 and gen_switch_params classname message commonVerb =
   let cutMessageName = cut_msg_name (pascal_case message.msg_name) commonVerb in
-  let switchName = if cutMessageName = "Host" then "XenHost" else cutMessageName in 
-    sprintf "
+  let switchName = if cutMessageName = "Host" then "XenHost" else cutMessageName in
+  sprintf "
         [Parameter(ParameterSetName = \"%s\", Mandatory = true)]
         public SwitchParameter %s
         {
@@ -1352,18 +1352,18 @@ and gen_switch_params classname message commonVerb =
         }
         private bool %s;
         private bool %sIsSpecified;\n"
-        switchName
-        switchName
-        (lower_and_underscore_first switchName)
-        (lower_and_underscore_first switchName)
-        (lower_and_underscore_first switchName)
-        (lower_and_underscore_first switchName)
-        (lower_and_underscore_first switchName)
+    switchName
+    switchName
+    (lower_and_underscore_first switchName)
+    (lower_and_underscore_first switchName)
+    (lower_and_underscore_first switchName)
+    (lower_and_underscore_first switchName)
+    (lower_and_underscore_first switchName)
 
 and print_async_param asyncMessages =
   match asyncMessages with
-    | []          -> ""
-    | _           -> sprintf "
+  | []          -> ""
+  | _           -> sprintf "
         protected override bool GenerateAsyncParam
         {
             get
@@ -1374,55 +1374,55 @@ and print_async_param asyncMessages =
 
 and condition messages =
   match messages with
-    | []          -> ""
-    | [x]         -> sprintf "%sIsSpecified" (lower_and_underscore_first x)
-    | hd::tl      -> sprintf "%sIsSpecified
+  | []          -> ""
+  | [x]         -> sprintf "%sIsSpecified" (lower_and_underscore_first x)
+  | hd::tl      -> sprintf "%sIsSpecified
                        ^ %s" (lower_and_underscore_first hd) (condition tl)
 
 and get_message_type message classname commonVerb =
   let messageParams = List.filter (fun x -> not (is_class x classname)) message.msg_params in
   match commonVerb with
-    | "Remove" ->
-        (match messageParams with
-           | [x] -> obj_internal_type x.param_type
-           | _   -> Printf.eprintf "%s" message.msg_name; assert false)
-    | "Add"    ->
-        (match messageParams with
-           | [x]   -> obj_internal_type x.param_type
-           | [x;y] -> sprintf "KeyValuePair<%s, %s>" 
-                        (obj_internal_type x.param_type) (obj_internal_type y.param_type)
-           | _     -> Printf.eprintf "%s" message.msg_name; assert false)
-    | "Set"    ->
-        (match messageParams with
-           | [x]    -> obj_internal_type x.param_type
-           | [x;y] when not (obj_internal_type x.param_type =
-                             obj_internal_type y.param_type) -> sprintf "KeyValuePair<%s, %s>"
-                               (obj_internal_type x.param_type) (obj_internal_type y.param_type)
-           | hd::tl -> let hdtype = obj_internal_type hd.param_type in
-                         if (List.for_all
-                               (fun x -> hdtype = (obj_internal_type x.param_type))
-                               tl) then sprintf "%s[]" hdtype
-                         else (Printf.eprintf "%s" message.msg_name; assert false)
-           | _      -> Printf.eprintf "%s" message.msg_name; assert false)
-    | "Get"    ->
-        (match messageParams with
-           | []  -> "SwitchParameter"
-           | [x] -> obj_internal_type x.param_type
-           | _   -> Printf.eprintf "%s" message.msg_name; assert false)
-    | _        -> ""
+  | "Remove" ->
+    (match messageParams with
+     | [x] -> obj_internal_type x.param_type
+     | _   -> Printf.eprintf "%s" message.msg_name; assert false)
+  | "Add"    ->
+    (match messageParams with
+     | [x]   -> obj_internal_type x.param_type
+     | [x;y] -> sprintf "KeyValuePair<%s, %s>"
+                  (obj_internal_type x.param_type) (obj_internal_type y.param_type)
+     | _     -> Printf.eprintf "%s" message.msg_name; assert false)
+  | "Set"    ->
+    (match messageParams with
+     | [x]    -> obj_internal_type x.param_type
+     | [x;y] when not (obj_internal_type x.param_type =
+                       obj_internal_type y.param_type) -> sprintf "KeyValuePair<%s, %s>"
+                                                            (obj_internal_type x.param_type) (obj_internal_type y.param_type)
+     | hd::tl -> let hdtype = obj_internal_type hd.param_type in
+       if (List.for_all
+             (fun x -> hdtype = (obj_internal_type x.param_type))
+             tl) then sprintf "%s[]" hdtype
+       else (Printf.eprintf "%s" message.msg_name; assert false)
+     | _      -> Printf.eprintf "%s" message.msg_name; assert false)
+  | "Get"    ->
+    (match messageParams with
+     | []  -> "SwitchParameter"
+     | [x] -> obj_internal_type x.param_type
+     | _   -> Printf.eprintf "%s" message.msg_name; assert false)
+  | _        -> ""
 
 
 and print_parameter_sets parameterSets =
   match parameterSets with
-    | []     -> "[Parameter]"
-    | [x]    -> sprintf "[Parameter(ParameterSetName = \"%s\")]" x
-    | hd::tl -> sprintf "[Parameter(ParameterSetName = \"%s\")]\n        %s"
-                  hd (print_parameter_sets tl)
+  | []     -> "[Parameter]"
+  | [x]    -> sprintf "[Parameter(ParameterSetName = \"%s\")]" x
+  | hd::tl -> sprintf "[Parameter(ParameterSetName = \"%s\")]\n        %s"
+                hd (print_parameter_sets tl)
 
 and print_parse_xenobject_private_method obj classname includeUuidAndName =
   let publicProperty = ocaml_class_to_csharp_property classname in
   let localVar = ocaml_class_to_csharp_local_var classname in
-    sprintf "
+  sprintf "
         private string Parse%s()
         {
             string %s = null;
@@ -1442,23 +1442,23 @@ and print_parse_xenobject_private_method obj classname includeUuidAndName =
 
             return %s;
         }\n"
-      publicProperty
-      localVar
-      publicProperty
-      localVar (qualified_class_name classname) publicProperty      
-      (if (has_uuid obj) && includeUuidAndName then
-        sprintf "
+    publicProperty
+    localVar
+    publicProperty
+    localVar (qualified_class_name classname) publicProperty
+    (if (has_uuid obj) && includeUuidAndName then
+       sprintf "
             else if (Uuid != Guid.Empty)
             {
                 var xenRef = %s.get_by_uuid(session, Uuid.ToString());
                 if (xenRef != null)
                     %s = xenRef.opaque_ref;
-            }"      
-          (qualified_class_name classname)
-          localVar
-       else sprintf "")
-      (if (has_name obj) && includeUuidAndName then
-        sprintf "
+            }"
+         (qualified_class_name classname)
+         localVar
+     else sprintf "")
+    (if (has_name obj) && includeUuidAndName then
+       sprintf "
             else if (Name != null)
             {
                 var xenRefs = %s.get_by_name_label(session, Name);
@@ -1470,48 +1470,48 @@ and print_parse_xenobject_private_method obj classname includeUuidAndName =
                         string.Empty,
                         ErrorCategory.InvalidArgument,
                         Name));
-            }"      
-          (qualified_class_name classname)
-          localVar
-          (qualified_class_name classname)
-       else sprintf "")
-      localVar
-      publicProperty      
-      (if (has_uuid obj) then sprintf ", 'Uuid'"
-      else sprintf "")      
-      publicProperty
-      localVar
+            }"
+         (qualified_class_name classname)
+         localVar
+         (qualified_class_name classname)
+     else sprintf "")
+    localVar
+    publicProperty
+    (if (has_uuid obj) then sprintf ", 'Uuid'"
+     else sprintf "")
+    publicProperty
+    localVar
 
 and print_process_record_private_methods classname messages commonVerb switch =
   match messages with
-    | []     -> sprintf ""
-    | hd::tl -> let cutMessageName = cut_msg_name (pascal_case hd.msg_name) commonVerb in
-                sprintf "
+  | []     -> sprintf ""
+  | hd::tl -> let cutMessageName = cut_msg_name (pascal_case hd.msg_name) commonVerb in
+    sprintf "
         private void ProcessRecord%s(string %s)
         {%s%s
             RunApiCall(()=>
             {%s
             });
         }\n%s"
-                cutMessageName (ocaml_class_to_csharp_local_var classname) ""
-                (gen_shouldprocess commonVerb hd classname)               
-                (gen_csharp_api_call hd classname commonVerb switch)                
-                (print_process_record_private_methods classname tl commonVerb switch)
+      cutMessageName (ocaml_class_to_csharp_local_var classname) ""
+      (gen_shouldprocess commonVerb hd classname)
+      (gen_csharp_api_call hd classname commonVerb switch)
+      (print_process_record_private_methods classname tl commonVerb switch)
 
 and gen_shouldprocess commonVerb message classname =
   match commonVerb with
-    | "Get" -> ""
-    | _     -> let theObj =
-                 (if classname = "pool" || commonVerb = "New" then "session.Url"
-                  else ocaml_class_to_csharp_local_var classname) in
-               sprintf "
+  | "Get" -> ""
+  | _     -> let theObj =
+               (if classname = "pool" || commonVerb = "New" then "session.Url"
+                else ocaml_class_to_csharp_local_var classname) in
+    sprintf "
             if (!ShouldProcess(%s, \"%s.%s\"))
                 return;\n" theObj (exposed_class_name classname) message.msg_name
 
 and gen_csharp_api_call message classname commonVerb switch =
   let asyncPipe = gen_csharp_api_call_async_pipe in
   let passThruTask =
-    if switch = "pipe" then asyncPipe 
+    if switch = "pipe" then asyncPipe
     else if (switch = "passthru" || switch = "asyncpassthru") then print_pass_thru asyncPipe
     else "" in
   let syncPipe = gen_csharp_api_call_sync_pipe message classname in
@@ -1519,10 +1519,10 @@ and gen_csharp_api_call message classname commonVerb switch =
     if switch = "pipe" then syncPipe
     else if switch = "passthru" then print_pass_thru syncPipe
     else "" in
-  if message.msg_async then 
+  if message.msg_async then
     sprintf "
                 var contxt = _context as %s;
-                
+
                 if (contxt != null && contxt.Async)
                 {%s%s
                 }
@@ -1539,16 +1539,16 @@ and gen_csharp_api_call message classname commonVerb switch =
       (gen_csharp_api_call_async message classname commonVerb) passThruTask
       (gen_csharp_api_call_sync message classname commonVerb) passThruResult
   else sprintf "%s%s%s"
-    (if (commonVerb = "Invoke") && (is_message_with_dynamic_params classname message) then
-      sprintf "var contxt = _context as Xen%sAction%sDynamicParameters;\n" 
+      (if (commonVerb = "Invoke") && (is_message_with_dynamic_params classname message) then
+         sprintf "var contxt = _context as Xen%sAction%sDynamicParameters;\n"
            (ocaml_class_to_csharp_class classname)
            (cut_msg_name (pascal_case message.msg_name) "Invoke")
-     else if (commonVerb = "Get") && (is_message_with_dynamic_params classname message) then
-      sprintf "var contxt = _context as Xen%sProperty%sDynamicParameters;\n" 
+       else if (commonVerb = "Get") && (is_message_with_dynamic_params classname message) then
+         sprintf "var contxt = _context as Xen%sProperty%sDynamicParameters;\n"
            (ocaml_class_to_csharp_class classname)
-           (cut_msg_name (pascal_case message.msg_name) "Get") 
-     else "")
-    (gen_csharp_api_call_sync message classname commonVerb) passThruResult
+           (cut_msg_name (pascal_case message.msg_name) "Get")
+       else "")
+      (gen_csharp_api_call_sync message classname commonVerb) passThruResult
 
 and print_pass_thru x = sprintf "
                     if (PassThru)
@@ -1557,8 +1557,8 @@ and print_pass_thru x = sprintf "
 
 and gen_csharp_api_call_async message classname commonVerb =
   sprintf "
-                    taskRef = %s.async_%s(%s);\n" 
-     (qualified_class_name classname)
+                    taskRef = %s.async_%s(%s);\n"
+    (qualified_class_name classname)
     (message.msg_name)
     (gen_call_params classname message commonVerb)
 
@@ -1570,44 +1570,44 @@ and gen_csharp_api_call_async_pipe =
                             taskObj = XenAPI.Task.get_record(session, taskRef.opaque_ref);
                             taskObj.opaque_ref = taskRef.opaque_ref;
                         }
-                    
+
                         WriteObject(taskObj, true);"
 
 and gen_csharp_api_call_sync message classname commonVerb =
   match message.msg_result with
-    | None                  -> sprintf "
+  | None                  -> sprintf "
                     %s.%s(%s);\n"
-                                 (qualified_class_name classname) (message.msg_name) 
-                                 (gen_call_params classname message commonVerb)
-    | Some (Ref r, _)       -> sprintf "
+                               (qualified_class_name classname) (message.msg_name)
+                               (gen_call_params classname message commonVerb)
+  | Some (Ref r, _)       -> sprintf "
                     string objRef = %s.%s(%s);\n"
-                                 (qualified_class_name classname) (message.msg_name)
-                                 (gen_call_params classname message commonVerb)
-    | Some (Set (Ref r), _) -> sprintf "
+                               (qualified_class_name classname) (message.msg_name)
+                               (gen_call_params classname message commonVerb)
+  | Some (Set (Ref r), _) -> sprintf "
                     var refs = %s.%s(%s);\n"
-                                 (qualified_class_name classname) 
-                                 (message.msg_name) (gen_call_params classname message commonVerb)
-    | Some (Map (u, v), _)  -> sprintf "
+                               (qualified_class_name classname)
+                               (message.msg_name) (gen_call_params classname message commonVerb)
+  | Some (Map (u, v), _)  -> sprintf "
                     var dict = %s.%s(%s);\n"
-                                 (qualified_class_name classname) (message.msg_name)
-                                 (gen_call_params classname message commonVerb)
-    | Some (x, _)           -> sprintf "
+                               (qualified_class_name classname) (message.msg_name)
+                               (gen_call_params classname message commonVerb)
+  | Some (x, _)           -> sprintf "
                     %s obj = %s.%s(%s);\n"
-                                 (exposed_type x) (qualified_class_name classname)
-                                 (message.msg_name) 
-                                 (gen_call_params classname message commonVerb)
+                               (exposed_type x) (qualified_class_name classname)
+                               (message.msg_name)
+                               (gen_call_params classname message commonVerb)
 
 and gen_csharp_api_call_sync_pipe message classname =
   match message.msg_result with
-    | None                  -> sprintf "
+  | None                  -> sprintf "
                         var obj = %s.get_record(session, %s);
                         if (obj != null)
                             obj.opaque_ref = %s;
                         WriteObject(obj, true);"
-                                 (qualified_class_name classname)
-                                 (ocaml_class_to_csharp_local_var classname)
-                                 (ocaml_class_to_csharp_local_var classname)
-    | Some (Ref r, _)       -> sprintf "
+                               (qualified_class_name classname)
+                               (ocaml_class_to_csharp_local_var classname)
+                               (ocaml_class_to_csharp_local_var classname)
+  | Some (Ref r, _)       -> sprintf "
                         %s obj = null;
 
                         if (objRef != \"OpaqueRef:NULL\")
@@ -1617,27 +1617,27 @@ and gen_csharp_api_call_sync_pipe message classname =
                         }
 
                         WriteObject(obj, true);"
-                                 (qualified_class_name r) (qualified_class_name r)
-    | Some (Set (Ref r), _) -> sprintf "
+                               (qualified_class_name r) (qualified_class_name r)
+  | Some (Set (Ref r), _) -> sprintf "
                         var records = new List<%s>();
 
                         foreach (var _ref in refs)
                         {
                             if (_ref.opaque_ref == \"OpaqueRef:NULL\")
                                 continue;
-                        
+
                             var record = %s.get_record(session, _ref);
                             record.opaque_ref = _ref.opaque_ref;
                             records.Add(record);
                         }
 
-                        WriteObject(records, true);" 
-                                 (qualified_class_name r)
-                                 (qualified_class_name r) 
-    | Some (Map (u, v), _)  -> sprintf "
+                        WriteObject(records, true);"
+                               (qualified_class_name r)
+                               (qualified_class_name r)
+  | Some (Map (u, v), _)  -> sprintf "
                         Hashtable ht = CommonCmdletFunctions.ConvertDictionaryToHashtable(dict);
                         WriteObject(ht, true);"
-    | Some (x, _)           -> sprintf "
+  | Some (x, _)           -> sprintf "
                         WriteObject(obj, true);"
 
 and gen_call_params classname message commonVerb =
@@ -1651,54 +1651,54 @@ and gen_param_list classname params message commonVerb =
      else if (commonVerb = "Invoke") && (List.mem (String.lowercase x.param_name) ["name";"uuid"]) then
        sprintf "contxt.%s" (ocaml_class_to_csharp_property x.param_name)^"Param"
      else if commonVerb = "Invoke" then
-       sprintf "contxt.%s" (ocaml_class_to_csharp_property x.param_name)      
+       sprintf "contxt.%s" (ocaml_class_to_csharp_property x.param_name)
      else if commonVerb = "Get" then
        sprintf "contxt.%s" (ocaml_class_to_csharp_property x.param_name)
      else if not (commonVerb = "New") then
-       cutMessageName       
+       cutMessageName
      else
        ocaml_class_to_csharp_property x.param_name) in
   let valueOfPair x =
     match x.param_type with
-      | Map(u, v) -> sprintf "CommonCmdletFunctions.ConvertHashTableToDictionary<%s, %s>(%s.Value)"
-                        (exposed_type u) (exposed_type v) cutMessageName
-      | _         -> cutMessageName^".Value" in
+    | Map(u, v) -> sprintf "CommonCmdletFunctions.ConvertHashTableToDictionary<%s, %s>(%s.Value)"
+                     (exposed_type u) (exposed_type v) cutMessageName
+    | _         -> cutMessageName^".Value" in
   let api_call_param x =
     match x.param_type with
-      |  Map(u, v) -> sprintf "CommonCmdletFunctions.ConvertHashTableToDictionary<%s, %s>(%s)"
-                        (exposed_type u) (exposed_type v) (get_param_name x)
-      | _          -> get_param_name x in
+    |  Map(u, v) -> sprintf "CommonCmdletFunctions.ConvertHashTableToDictionary<%s, %s>(%s)"
+                      (exposed_type u) (exposed_type v) (get_param_name x)
+    | _          -> get_param_name x in
   let messageParams = List.filter (fun x -> not (is_class x classname)) message.msg_params in
   let restParams = List.filter (fun x -> is_class x classname) message.msg_params in
   let procParams = List.map get_param_name restParams in
   match commonVerb with
-    | "Remove" ->
-        (match messageParams with
-           | []  -> procParams
-           | [x] -> procParams@[api_call_param x]
-           | _   -> Printf.eprintf "%s" message.msg_name; assert false)
-    | "Add"    ->
-        (match messageParams with
-           | [x]   -> procParams@[api_call_param x]
-           | [x;y] -> procParams@[cutMessageName^".Key"; valueOfPair y]
-           | _     ->  Printf.eprintf "%s" message.msg_name; assert false)
-    | "Set"    ->
-        (match messageParams with
-           | [x]    -> procParams@[api_call_param x]
-           | [x;y] when not (obj_internal_type x.param_type =
-                             obj_internal_type y.param_type) ->
-                                procParams@[cutMessageName^".Key"; valueOfPair y]
-           | hd::tl -> let argList = ref [] in 
-                       let hdtype = obj_internal_type hd.param_type in
-                         if (List.for_all (fun x ->
-                             hdtype = (obj_internal_type x.param_type)) tl) then
-                           (explode_array cutMessageName (List.length messageParams) argList;
-                            procParams@(!argList))
-                         else (Printf.eprintf "%s" message.msg_name; assert false)
-           | _      -> Printf.eprintf "%s" message.msg_name; assert false)
-    | _      -> (match params with
-           |  []    -> []
-           |  h::tl -> (api_call_param h)::(gen_param_list classname tl message commonVerb))
+  | "Remove" ->
+    (match messageParams with
+     | []  -> procParams
+     | [x] -> procParams@[api_call_param x]
+     | _   -> Printf.eprintf "%s" message.msg_name; assert false)
+  | "Add"    ->
+    (match messageParams with
+     | [x]   -> procParams@[api_call_param x]
+     | [x;y] -> procParams@[cutMessageName^".Key"; valueOfPair y]
+     | _     ->  Printf.eprintf "%s" message.msg_name; assert false)
+  | "Set"    ->
+    (match messageParams with
+     | [x]    -> procParams@[api_call_param x]
+     | [x;y] when not (obj_internal_type x.param_type =
+                       obj_internal_type y.param_type) ->
+       procParams@[cutMessageName^".Key"; valueOfPair y]
+     | hd::tl -> let argList = ref [] in
+       let hdtype = obj_internal_type hd.param_type in
+       if (List.for_all (fun x ->
+           hdtype = (obj_internal_type x.param_type)) tl) then
+         (explode_array cutMessageName (List.length messageParams) argList;
+          procParams@(!argList))
+       else (Printf.eprintf "%s" message.msg_name; assert false)
+     | _      -> Printf.eprintf "%s" message.msg_name; assert false)
+  | _      -> (match params with
+      |  []    -> []
+      |  h::tl -> (api_call_param h)::(gen_param_list classname tl message commonVerb))
 
 and explode_array name length result =
   for i = length -1 downto 0
@@ -1711,4 +1711,4 @@ and is_class param classname =
   (String.lowercase param.param_name) = (String.lowercase classname)
 
 let _ =
-   main()
+  main()


### PR DESCRIPTION
It's easier if the commits are reviewed separately as the first one is loads of whitespace.
The second one restores in the autogenerated output the broken `Get-XenMessage` and removes completely the empty `Get-Xen<T> where T: Auth, DataSource, LVHD, User, VTPM`.