### PR TITLE
CP-24819 Enum now has 3 arguments

### DIFF
--- a/csharp/gen_csharp_binding.ml
+++ b/csharp/gen_csharp_binding.ml
@@ -957,7 +957,7 @@ and gen_proxy_field out_chan content =
 
 
 and gen_enum = function
-  | Enum(name, contents) ->
+  | Enum(name, _, contents) ->
     if not (List.mem name !api_members) then
       api_members := name::!api_members;
     let out_chan = open_out (Filename.concat destdir (name ^ ".cs"))
@@ -1157,11 +1157,11 @@ and exposed_type = function
   | DateTime                -> "DateTime"
   | Ref name                -> sprintf "XenRef<%s>" (exposed_class_name name)
   | Set(Ref name)           -> sprintf "List<XenRef<%s>>" (exposed_class_name name)
-  | Set(Enum(name, _) as x) -> enums := TypeSet.add x !enums;
+  | Set(Enum(name,_,_) as x)-> enums := TypeSet.add x !enums;
     sprintf "List<%s>" name
   | Set(Int)                -> "long[]"
   | Set(String)             -> "string[]"
-  | Enum(name, _) as x      -> enums := TypeSet.add x !enums; name
+  | Enum(name,_,_) as x     -> enums := TypeSet.add x !enums; name
   | Map(u, v)               -> sprintf "Dictionary<%s, %s>" (exposed_type u)
                                  (exposed_type v)
   | Record name             -> exposed_class_name name
@@ -1196,7 +1196,7 @@ and convert_from_proxy thing ty = (*function*)
   | Float               -> simple_convert_from_proxy thing ty
   | Int                 -> sprintf "%s == null ? 0 : %s" thing (simple_convert_from_proxy thing ty)
   | Set(String)         -> sprintf "%s == null ? new string[] {} : %s" thing (simple_convert_from_proxy thing ty)
-  | Enum(name, _)       -> sprintf "%s == null ? (%s) 0 : %s" thing name (simple_convert_from_proxy thing ty)
+  | Enum(name,_,_)      -> sprintf "%s == null ? (%s) 0 : %s" thing name (simple_convert_from_proxy thing ty)
   | _                   -> sprintf "%s == null ? null : %s" thing (simple_convert_from_proxy thing ty)
 
 and convert_from_proxy_never_null_string thing ty = (* for when 'thing' is never null and is a string - i.e. it is a key in a hashtable *)
@@ -1217,8 +1217,8 @@ and convert_from_hashtable fname ty =
   | String              -> sprintf "Marshalling.ParseString(table, %s)" field
   | Set(String)         -> sprintf "Marshalling.ParseStringArray(table, %s)" field
   | Set(Ref name)       -> sprintf "Marshalling.ParseSetRef<%s>(table, %s)" (exposed_class_name name) field
-  | Set(Enum(name, _))  -> sprintf "Helper.StringArrayToEnumList<%s>(Marshalling.ParseStringArray(table, %s))" name field
-  | Enum(name, _)       -> sprintf "(%s)Helper.EnumParseDefault(typeof(%s), Marshalling.ParseString(table, %s))" name name field
+  | Set(Enum(name,_,_)) -> sprintf "Helper.StringArrayToEnumList<%s>(Marshalling.ParseStringArray(table, %s))" name field
+  | Enum(name,_,_)      -> sprintf "(%s)Helper.EnumParseDefault(typeof(%s), Marshalling.ParseString(table, %s))" name name field
   | Map(Ref name, Record _) -> sprintf "Marshalling.ParseMapRefRecord<%s, Proxy_%s>(table, %s)" (exposed_class_name name) (exposed_class_name name) field
   | Map(u, v) as x      ->
     maps := TypeSet.add x !maps;
@@ -1246,8 +1246,8 @@ and simple_convert_from_proxy thing ty =
   | String              -> sprintf "(string)%s" thing
   | Set(String)         -> sprintf "(string [])%s" thing
   | Set(Ref name)       -> sprintf "XenRef<%s>.Create(%s)" (exposed_class_name name) thing
-  | Set(Enum(name, _))  -> sprintf "Helper.StringArrayToEnumList<%s>(%s)" name thing
-  | Enum(name, _)       -> sprintf "(%s)Helper.EnumParseDefault(typeof(%s), (string)%s)" name name thing
+  | Set(Enum(name,_,_)) -> sprintf "Helper.StringArrayToEnumList<%s>(%s)" name thing
+  | Enum(name,_,_)      -> sprintf "(%s)Helper.EnumParseDefault(typeof(%s), (string)%s)" name name thing
   | Map(Ref name, Record _) -> sprintf "XenRef<%s>.Create<Proxy_%s>(%s)" (exposed_class_name name) (exposed_class_name name) thing
   | Map(u, v) as x      ->
     maps := TypeSet.add x !maps;
@@ -1272,11 +1272,11 @@ and convert_to_proxy thing ty = (*function*)
   | Float               -> thing
   | Ref _               -> sprintf "%s ?? \"\"" thing
   | String              -> sprintf "%s ?? \"\"" thing
-  | Enum (name,_)       -> sprintf "%s_helper.ToString(%s)" name thing
-  | Set (Ref name)         -> sprintf "(%s != null) ? Helper.RefListToStringArray(%s) : new string[] {}" thing thing
+  | Enum (name,_,_)     -> sprintf "%s_helper.ToString(%s)" name thing
+  | Set (Ref name)      -> sprintf "(%s != null) ? Helper.RefListToStringArray(%s) : new string[] {}" thing thing
   | Set(String)         -> thing
   | Set (Int) -> sprintf "(%s != null) ? Helper.LongArrayToStringArray(%s) : new string[] {}" thing thing
-  | Set(Enum(_, _))  -> sprintf "(%s != null) ? Helper.ObjectListToStringArray(%s) : new string[] {}" thing thing
+  | Set(Enum(_,_,_))    -> sprintf "(%s != null) ? Helper.ObjectListToStringArray(%s) : new string[] {}" thing thing
   | Map(u, v) as x      -> maps := TypeSet.add x !maps;
     sprintf "%s(%s)"
       (sanitise_function_name (sprintf "Maps.convert_to_proxy_%s_%s" (exposed_type_as_literal u) (exposed_type_as_literal v))) thing

--- a/powershell/common_functions.ml
+++ b/powershell/common_functions.ml
@@ -147,10 +147,10 @@ and exposed_type = function
   | DateTime                -> "DateTime"
   | Ref name                -> sprintf "XenRef<%s>" (qualified_class_name name)
   | Set(Ref name)           -> sprintf "List<XenRef<%s>>" (qualified_class_name name)
-  | Set(Enum(name, _))      -> sprintf "List<%s>" name
+  | Set(Enum(name,_,_))     -> sprintf "List<%s>" name
   | Set(Int)                -> "long[]"
   | Set(String)             -> "string[]"
-  | Enum(name, _)           -> name
+  | Enum(name,_,_)          -> name
   | Map(u, v)               -> sprintf "Dictionary<%s, %s>" (exposed_type u)
                                  (exposed_type v)
   | Record name             -> qualified_class_name name

--- a/powershell/gen_powershell_binding.ml
+++ b/powershell/gen_powershell_binding.ml
@@ -643,8 +643,8 @@ and convert_from_hashtable fname ty =
   | Set(String)          -> sprintf "Marshalling.ParseStringArray(HashTable, %s)" field
   | Set(Ref x)           -> sprintf "Marshalling.ParseSetRef<%s>(HashTable, %s)"
                               (exposed_class_name x) field
-  | Set(Enum(x, _))      -> sprintf "Helper.StringArrayToEnumList<%s>(Marshalling.ParseStringArray(HashTable, %s))" x field
-  | Enum(x, _)           -> sprintf "(%s)CommonCmdletFunctions.EnumParseDefault(typeof(%s), Marshalling.ParseString(HashTable, %s))"
+  | Set(Enum(x,_,_))     -> sprintf "Helper.StringArrayToEnumList<%s>(Marshalling.ParseStringArray(HashTable, %s))" x field
+  | Enum(x,_,_)          -> sprintf "(%s)CommonCmdletFunctions.EnumParseDefault(typeof(%s), Marshalling.ParseString(HashTable, %s))"
                               x x field
   | Map(Ref x, Record _) -> sprintf "Marshalling.ParseMapRefRecord<%s, Proxy_%s>(HashTable, %s)"
                               (exposed_class_name x) (exposed_class_name x) field


### PR DESCRIPTION
Commit 3494cda409dd7529c02ce599cda60300f18c7ea1 in xen-api.git
introduced a change to the Enum data constructor, which now takes 3
arguments. This requires changing it here. The new argument is simply
being ignored.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>