### PR TITLE
Revert "CP-24819 Enum now has 3 arguments"

### DIFF
--- a/c/gen_c_binding.ml
+++ b/c/gen_c_binding.ml
@@ -152,7 +152,7 @@ and gen_class f g clas targetdir =
 
 
 and gen_enum f g targetdir = function
-  | Enum(name, _, contents) ->
+  | Enum(name, contents) ->
     if not (List.mem name !all_headers) then
       all_headers := name::!all_headers;
     let out_chan = open_out (Filename.concat targetdir (g name))
@@ -502,7 +502,7 @@ and abstract_result_handling needed classname msg_name param_count = function
     return session->ok;
 " record_tn (initialiser_of_ty (Record n)) call
 
-    | Enum(e, _, _) ->
+    | Enum(e, _) ->
       sprintf
         "%s
     %s
@@ -545,7 +545,7 @@ and abstract_result_type typ =
 
 and abstract_type record = function
   | String      -> "abstract_type_string"
-  | Enum(n, _, _)  ->
+  | Enum(n, _)  ->
     sprintf "%s_abstract_type_" (typename n)
   | Ref _       ->
     if record then
@@ -556,7 +556,7 @@ and abstract_type record = function
   | Float       -> "abstract_type_float"
   | Bool        -> "abstract_type_bool"
   | DateTime    -> "abstract_type_datetime"
-  | Set (Enum(n, _, _)) ->
+  | Set (Enum(n, _)) ->
     sprintf "%s_set_abstract_type_" (typename n)
   | Set (Record "event") ->
     "xen_event_record_set_abstract_type_"
@@ -569,8 +569,8 @@ and abstract_type record = function
       sprintf "abstract_type_%s_ref_map" (name_of_ty l)
     else
       sprintf "abstract_type_%s_string_map" (name_of_ty l)
-  | Map((Enum(_,_,_) as l), r) -> (mapname l r) ^ "_abstract_type_"
-  | Map(l, (Enum(_,_,_) as r)) -> (mapname l r) ^ "_abstract_type_"
+  | Map((Enum(_,_) as l), r) -> (mapname l r) ^ "_abstract_type_"
+  | Map(l, (Enum(_,_) as r)) -> (mapname l r) ^ "_abstract_type_"
   | Map(l, r) -> sprintf "abstract_type_" ^ (mapname l r)
 
   | Record n -> sprintf "%s_abstract_type_" (record_typename n)
@@ -923,8 +923,8 @@ void
 
   begin
     match l, r with
-      (Enum(_,_,_), _) -> gen_enum_map_abstract_type print name l r
-    | (_, Enum(_,_,_)) -> gen_enum_map_abstract_type print name l r
+      (Enum(_, _), _) -> gen_enum_map_abstract_type print name l r
+    | (_, Enum(_, _)) -> gen_enum_map_abstract_type print name l r
     | _ -> ()
   end
 
@@ -968,7 +968,7 @@ extern const abstract_type %s_abstract_type_;
 
 
 and hash_include_enum = function
-    Enum(x,_,_) ->
+    Enum(x, _) ->
     "\n" ^ hash_include x
   | _ ->
     ""
@@ -1220,13 +1220,13 @@ and find_needed'' needed = function
   | Float
   | Bool
   | DateTime -> ()
-  | Enum (n, _, _) ->
+  | Enum (n, _) ->
     needed := StringSet.add (n ^ "_internal") !needed
   | Ref n ->
     needed := StringSet.add n !needed
   | Set(Ref n) ->
     needed := StringSet.add n !needed
-  | Set(Enum (e, _, _)) ->
+  | Set(Enum (e, _)) ->
     needed := StringSet.add e !needed;
     needed := StringSet.add (e ^ "_internal") !needed
   | Set(Record "event") ->
@@ -1251,10 +1251,10 @@ and free_impl val_name record = function
   | Float
   | Bool
   | DateTime
-  | Enum (_, _, _)   -> ""
+  | Enum (_, _)      -> ""
   | Ref n            -> sprintf "%s_free(%s);" (if record then record_opt_typename n else typename n) val_name
   | Set(Ref n)       -> sprintf "%s_opt_set_free(%s);" (record_typename n) val_name
-  | Set(Enum (e,_,_))-> sprintf "%s_set_free(%s);" (typename e) val_name
+  | Set(Enum (e, _)) -> sprintf "%s_set_free(%s);" (typename e) val_name
   | Set(String)      -> sprintf "xen_string_set_free(%s);" val_name
   | Map(l, r)        -> let n = mapname l r in
     sprintf "%s_free(%s);" (typename n) val_name
@@ -1264,14 +1264,14 @@ and free_impl val_name record = function
 
 
 and add_enum_internal needed = function
-  | Enum(x,_,_) -> StringSet.add (x ^ "_internal") needed
-  | _           -> needed
+  | Enum(x, _) -> StringSet.add (x ^ "_internal") needed
+  | _          -> needed
 
 
 and add_enum_map_internal needed l r =
   match (l, r) with
-    (Enum(_,_,_), _) -> StringSet.add ((mapname l r) ^ "_internal") needed
-  | (_, Enum(_,_,_)) -> StringSet.add ((mapname l r) ^ "_internal") needed
+    (Enum(_, _), _) -> StringSet.add ((mapname l r) ^ "_internal") needed
+  | (_, Enum(_, _)) -> StringSet.add ((mapname l r) ^ "_internal") needed
   | _ -> needed
 
 
@@ -1288,7 +1288,7 @@ and c_type_of_ty needed record = function
       sprintf "struct %s *" (record_opt_typename name)
     else
       sprintf "%s " (typename name)
-  | Enum(name, _, cs) as x ->
+  | Enum(name, cs) as x ->
     needed := StringSet.add name !needed;
     enums := TypeSet.add x !enums;
     c_type_of_enum name
@@ -1298,7 +1298,7 @@ and c_type_of_ty needed record = function
       sprintf "struct %s_set *" (record_opt_typename name)
     else
       sprintf "struct %s_set *" (typename name)
-  | Set (Enum (e,_,_) as x) ->
+  | Set (Enum (e, _) as x) ->
     let enum_typename = typename e in
     needed := StringSet.add e !needed;
     enums := TypeSet.add x !enums;
@@ -1317,8 +1317,8 @@ and c_type_of_ty needed record = function
     maps := TypeSet.add x !maps;
     begin
       match (l, r) with
-        (Enum(_,_,_), _) -> enum_maps := TypeSet.add x !enum_maps
-      | (_, Enum(_,_,_)) -> enum_maps := TypeSet.add x !enum_maps
+        (Enum(_, _), _) -> enum_maps := TypeSet.add x !enum_maps
+      | (_, Enum(_, _)) -> enum_maps := TypeSet.add x !enum_maps
       | _ -> ()
     end;
     sprintf "%s *" (typename n)
@@ -1351,7 +1351,7 @@ and name_of_ty = function
   | Float    -> "float"
   | Bool     -> "bool"
   | DateTime -> "datetime"
-  | Enum(x,_,_) -> x
+  | Enum(x, _) -> x
   | Set(x)   -> sprintf "%s_set" (name_of_ty x)
   | Ref(x)   -> x
   | Map(l,r) -> sprintf "%s_%s_map" (name_of_ty l) (name_of_ty r)

--- a/java/main.ml
+++ b/java/main.ml
@@ -171,7 +171,7 @@ let rec get_java_type ty =
   | Float         -> "Double"
   | Bool          -> "Boolean"
   | DateTime      -> "Date"
-  | Enum(name,_,ls)-> Hashtbl.replace enums name ls; sprintf "Types.%s" (class_case name)
+  | Enum(name,ls) -> Hashtbl.replace enums name ls; sprintf "Types.%s" (class_case name)
   | Set(t1)       -> sprintf "Set<%s>" (get_java_type t1)
   | Map(t1, t2)   -> sprintf "Map<%s, %s>" (get_java_type t1) (get_java_type t2)
   | Ref(ty)       -> class_case ty (* We want to hide all refs *)
@@ -180,7 +180,7 @@ let rec get_java_type ty =
 
 (*We'd like the list of XenAPI objects to appear as an enumeration so we can*)
 (* switch on them, so add it using this mechanism*)
-let switch_enum = (Enum ("XenAPIObjects", false,(List.map (fun x -> (x.name,x.description )) classes)));;
+let switch_enum = (Enum ("XenAPIObjects", (List.map (fun x -> (x.name,x.description )) classes)));;
 let _ = (get_java_type switch_enum);;
 
 (*Helper function for get_marshall_function*)
@@ -190,7 +190,7 @@ let rec get_marshall_function_rec = function
   | Float         -> "Double"
   | Bool          -> "Boolean"
   | DateTime      -> "Date"
-  | Enum(name,_,ls)-> class_case name
+  | Enum(name,ls) -> class_case name
   | Set(t1)       -> sprintf "SetOf%s" (get_marshall_function_rec t1)
   | Map(t1, t2)   -> sprintf "MapOf%s%s" (get_marshall_function_rec t1) (get_marshall_function_rec t2)
   | Ref(ty)       -> class_case ty (* We want to hide all refs *)
@@ -403,8 +403,8 @@ let field_default = function
   | Float         -> "0.0"
   | Bool          -> "false"
   | DateTime      -> "new Date(0)"
-  | Enum("vif_locking_mode",_,_) -> "Types.VifLockingMode.NETWORK_DEFAULT"  (* XOP-372 *)
-  | Enum(name,_,_)-> sprintf "Types.%s.UNRECOGNIZED" (class_case name)
+  | Enum("vif_locking_mode", _) -> "Types.VifLockingMode.NETWORK_DEFAULT"  (* XOP-372 *)
+  | Enum(name, _) -> sprintf "Types.%s.UNRECOGNIZED" (class_case name)
   | Set(t1)       -> sprintf "new LinkedHashSet<%s>()" (get_java_type t1)
   | Map(t1, t2)   -> sprintf "new HashMap<%s, %s>()" (get_java_type t1) (get_java_type t2)
   | Ref(ty)       -> sprintf "new %s(\"OpaqueRef:NULL\")" (class_case ty)
@@ -636,7 +636,7 @@ let gen_marshall_body file = function
         }\n"
 
   | Ref(ty)       -> fprintf file "        return new %s((String) object);\n" (class_case ty)
-  | Enum(name,_,ls) ->
+  | Enum(name,ls) ->
     fprintf file "        try {\n";
     fprintf file "            return %s.valueOf(((String) object).toUpperCase().replace('-','_'));\n" (class_case name);
     fprintf file "        } catch (IllegalArgumentException ex) {\n";

--- a/powershell/common_functions.ml
+++ b/powershell/common_functions.ml
@@ -147,10 +147,10 @@ and exposed_type = function
   | DateTime                -> "DateTime"
   | Ref name                -> sprintf "XenRef<%s>" (qualified_class_name name)
   | Set(Ref name)           -> sprintf "List<XenRef<%s>>" (qualified_class_name name)
-  | Set(Enum(name,_,_))     -> sprintf "List<%s>" name
+  | Set(Enum(name, _))      -> sprintf "List<%s>" name
   | Set(Int)                -> "long[]"
   | Set(String)             -> "string[]"
-  | Enum(name,_,_)          -> name
+  | Enum(name, _)           -> name
   | Map(u, v)               -> sprintf "Dictionary<%s, %s>" (exposed_type u)
                                  (exposed_type v)
   | Record name             -> qualified_class_name name

--- a/powershell/gen_powershell_binding.ml
+++ b/powershell/gen_powershell_binding.ml
@@ -643,8 +643,8 @@ and convert_from_hashtable fname ty =
   | Set(String)          -> sprintf "Marshalling.ParseStringArray(HashTable, %s)" field
   | Set(Ref x)           -> sprintf "Marshalling.ParseSetRef<%s>(HashTable, %s)"
                               (exposed_class_name x) field
-  | Set(Enum(x,_,_))     -> sprintf "Helper.StringArrayToEnumList<%s>(Marshalling.ParseStringArray(HashTable, %s))" x field
-  | Enum(x,_,_)          -> sprintf "(%s)CommonCmdletFunctions.EnumParseDefault(typeof(%s), Marshalling.ParseString(HashTable, %s))"
+  | Set(Enum(x, _))      -> sprintf "Helper.StringArrayToEnumList<%s>(Marshalling.ParseStringArray(HashTable, %s))" x field
+  | Enum(x, _)           -> sprintf "(%s)CommonCmdletFunctions.EnumParseDefault(typeof(%s), Marshalling.ParseString(HashTable, %s))"
                               x x field
   | Map(Ref x, Record _) -> sprintf "Marshalling.ParseMapRefRecord<%s, Proxy_%s>(HashTable, %s)"
                               (exposed_class_name x) (exposed_class_name x) field


### PR DESCRIPTION
This requires more changes because the compilation triggered by the
build-before.sh script breaks.

This reverts commit 66eda99294777d91989acd8f14120f8ea2e6b542.