### PR TITLE
CA-267461: Fix powershell bindings generator for some constructors

### DIFF
--- a/powershell/gen_powershell_binding.ml
+++ b/powershell/gen_powershell_binding.ml
@@ -599,13 +599,13 @@ and explode_record_fields message fields =
   let print_map tl hd =
     sprintf "
                 %s = CommonCmdletFunctions.ConvertDictionaryToHashtable(Record.%s);%s"
-      (exposed_class_name (pascal_case (full_name hd)))
+      (ocaml_class_to_csharp_property (full_name hd))
       (full_name hd)
       (explode_record_fields message tl) in
   let print_record tl hd =
     sprintf "
                 %s = Record.%s;%s"
-      (exposed_class_name (pascal_case (full_name hd)))
+      (ocaml_class_to_csharp_property (full_name hd))
       (full_name hd)
       (explode_record_fields message tl) in
   match fields with


### PR DESCRIPTION
The problem was in New-XenClusterHost.cs, we had the following code
generated:

```
    [Parameter(ParameterSetName = "Fields")]
    public XenRef<XenAPI.Cluster> Cluster { get; set; }

    [Parameter(ParameterSetName = "Fields")]
    public XenRef<XenAPI.Host> XenHost { get; set; }
...
    if (Record != null)
    {
        Cluster = Record.cluster;
        Host = Record.host;
    }
```

where Cluster was being set correctly, but it was trying to assign
to Host rather than XenHost. The Hashtbl implementation slightly
further on was correct:

```
    Cluster = Marshalling.ParseRef<Cluster>(HashTable, "cluster");
    XenHost = Marshalling.ParseRef<Host>(HashTable, "host");

```

The fix it to use the code used in the Hashtbl part, which is a
call to `ocaml_class_to_csharp_property x` rather than
`exposed_class_name (pascal_case x)`. Turns out the implementation
of `ocaml_class_to_csharp_property` is:

```ocaml
let ocaml_class_to_csharp_property classname =
  if (classname = "host") then "XenHost"
  else (exposed_class_name (pascal_case classname))
```

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>