### PR TITLE
CA-281881: G11N: L10N: Hardcode issue in error messages when configur…

### DIFF
--- a/csharp/FriendlyErrorNames.resx
+++ b/csharp/FriendlyErrorNames.resx
@@ -544,7 +544,7 @@
     <value>External authentication has been disabled with errors: Some AD machine accounts were not disabled on the AD server due to invalid credentials.</value>
   </data>
   <data name="POOL_AUTH_ENABLE_FAILED" xml:space="preserve">
-    <value>Could not enable external authentication: {1}</value>
+    <value>Could not enable external authentication.</value>
   </data>
   <data name="POOL_AUTH_ENABLE_FAILED_DOMAIN_LOOKUP_FAILED" xml:space="preserve">
     <value>The server was unable to contact your domain server to enable external authentication. Check that your settings are correct and a route to the server exists.</value>


### PR DESCRIPTION
…e AD for server

Refer to the CA ticket for details. Generall, there may be some messages (strings)
from the same error message and we cannot literally translate that in the current
framework nor can we split the error into multiple errors and make the translation
separately due to effort constrain. So we just remove the extra information/string
from the current error message to keep current message language(translation) consistent.

Signed-off-by: YarsinCitrix <yarsin.he@citrix.com>