### PR TITLE
helpers: Add out_indent for compat with ocaml 4.06

### DIFF
--- a/c/helper.ml
+++ b/c/helper.ml
@@ -66,6 +66,7 @@ let comment doc ?(indent = 0) s =
     out_newline = (fun () ->
         out (Printf.sprintf "\n%s * " indent_str) 0 (indent + 4));
     out_spaces = spaces;
+    out_indent = spaces;
   } in
   Format.pp_set_formatter_out_functions formatter funcs;
 


### PR DESCRIPTION
This integrates a patch that was applied during the build process.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>