### PR TITLE
CA-305383: PropertiesDialog was saving unchanged Snapshot Schedule in…

### DIFF
--- a/csharp/src/Helper.cs
+++ b/csharp/src/Helper.cs
@@ -66,9 +66,9 @@ namespace XenAPI
                 return true;
             if (o1 == null || o2 == null)
                 return o1 == null && IsEmptyCollection(o2) || o2 == null && IsEmptyCollection(o1);
-            if (typeof(T) is IDictionary)
+            if (o1 is IDictionary)
                 return AreDictEqual((IDictionary)o1, (IDictionary)o2);
-            if (typeof(T) is System.Collections.ICollection)
+            if (o1 is ICollection)
                 return AreCollectionsEqual((ICollection)o1, (ICollection)o2);
             return o1.Equals(o2);
         }


### PR DESCRIPTION
…formation back to the server unnecessarily.

Noticed while working on CA-301907.

Correct Helper.AreEqual2 which considered identical (but not reference equal) generic lists or dictionaries as being different.

Signed-off-by: Aaron Robson <aaron.robson@citrix.com>