### PR TITLE
Simplify Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,8 @@ env:
   global:
     - OCAML_VERSION=4.07
     - PACKAGE=xen-api-sdk
+    - PINS="xen-api-sdk:."
     - DISTRO="debian-stable"
     - TESTS=false
     - INSTALL=false
-  matrix:
-    - BASE_REMOTE=git://github.com/xapi-project/xs-opam
-    - EXTRA_REMOTES=git://github.com/xapi-project/xs-opam
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: EXTRA_REMOTES=git://github.com/xapi-project/xs-opam
+    - BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"


### PR DESCRIPTION
I see that one of the travis builds keeps failing (and the one with allowed failure passing): https://travis-ci.org/xapi-project/xen-api-sdk/builds/547159404

Use just one remote, and use an https URL.
opam update seems to fail with a git URL.