### PR TITLE
travis: pull settings from xs-opam

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,14 @@
 language: c
 sudo: required
-services: docker
+service: docker
 install:
-  - wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-docker.sh
-script:
-  - bash -ex .travis-docker.sh
+  - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+  - wget https://raw.githubusercontent.com/xapi-project/xs-opam/master/tools/xs-opam-ci.env
+  - source xs-opam-ci.env
+script: bash -ex .travis-docker.sh
 env:
   global:
-    - OCAML_VERSION=4.07
     - PACKAGE=xen-api-sdk
     - PINS="xen-api-sdk:."
-    - DISTRO="debian-stable"
     - TESTS=false
     - INSTALL=false
-    - BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"


### PR DESCRIPTION
This allows the SDK to automatically get build with up-to-date ci settings