### PR TITLE
Removed error message override because it has been outdated by the original API error message.

### DIFF
--- a/csharp/FriendlyErrorNames.resx
+++ b/csharp/FriendlyErrorNames.resx
@@ -162,9 +162,6 @@
   <data name="HOST_STILL_BOOTING" xml:space="preserve">
     <value>The server is still booting.</value>
   </data>
-  <data name="HOST_UNKNOWN_TO_MASTER" xml:space="preserve">
-    <value>The master says the server is not known to it. Perhaps the server was deleted from the master's database?</value>
-  </data>
   <data name="IMPORT_ERROR" xml:space="preserve">
     <value>This file could not be imported</value>
   </data>


### PR DESCRIPTION
Please review but do not merge before this PR https://github.com/xapi-project/xen-api/pull/4157 hits master.