### PR TITLE
CA-345342: Made the query parameters of the http actions optional

### DIFF
--- a/csharp/autogen/src/HTTP.cs
+++ b/csharp/autogen/src/HTTP.cs
@@ -358,37 +358,31 @@ namespace XenAPI
                     flatargs.Add(arg);
             }
 
-            UriBuilder uri = new UriBuilder();
-            uri.Scheme = "https";
-            uri.Port = DEFAULT_HTTPS_PORT;
-            uri.Host = hostname;
-            uri.Path = path;
-
-            StringBuilder query = new StringBuilder();
+            var query = new StringBuilder();
             for (int i = 0; i < flatargs.Count - 1; i += 2)
             {
-                string kv;
-
-                // If the argument is null, don't include it in the URL
-                if (flatargs[i + 1] == null)
+                if (flatargs[i + 1] == null)//skip null arguments
                     continue;
-
-                // bools are special because some xapi calls use presence/absence and some
-                // use "b=true" (not "True") and "b=false". But all accept "b=true" or absent.
-                if (flatargs[i + 1] is bool)
-                {
-                    if (!((bool)flatargs[i + 1]))
-                        continue;
-                    kv = flatargs[i] + "=true";
-                }
-                else
-                    kv = flatargs[i] + "=" + Uri.EscapeDataString(flatargs[i + 1].ToString());
 
                 if (query.Length != 0)
                     query.Append('&');
-                query.Append(kv);
+
+                query.Append(flatargs[i]).Append("=");
+
+                if (flatargs[i + 1] is bool)
+                    query.Append((bool)flatargs[i + 1] ? "true" : "false");
+                else
+                    query.Append(Uri.EscapeDataString(flatargs[i + 1].ToString()));
             }
-            uri.Query = query.ToString();
+
+            UriBuilder uri = new UriBuilder
+            {
+                Scheme = "https",
+                Port = DEFAULT_HTTPS_PORT,
+                Host = hostname,
+                Path = path,
+                Query = query.ToString()
+            };
 
             return uri.Uri;
         }

--- a/csharp/gen_csharp_binding.ml
+++ b/csharp/gen_csharp_binding.ml
@@ -178,15 +178,15 @@ and gen_http_actions() =
    (unique public name, (HTTP method, URI, whether to expose in SDK, [args to expose in SDK], [allowed_roles], [(sub-action,allowed_roles)]))
 *)
   let decl_of_sdkarg = function
-    | String_query_arg s -> "string " ^ (escaped s)
-    | Int64_query_arg s -> "long " ^ (escaped s)
-    | Bool_query_arg s -> "bool " ^ (escaped s)
+    | String_query_arg s -> sprintf "string %s = null" (escaped s)
+    | Int64_query_arg s -> sprintf "long? %s = null" (escaped s)
+    | Bool_query_arg s -> sprintf "bool? %s = null" (escaped s)
     | Varargs_query_arg -> "params string[] args /* alternate names and values */"
   in
   let use_of_sdkarg =  function
     | String_query_arg s
     | Int64_query_arg s
-    | Bool_query_arg s -> sprintf "\"%s\", %s" s (escaped s)
+    | Bool_query_arg s -> sprintf {|"%s", %s|} s (escaped s)
     | Varargs_query_arg -> "args"
   in
   let delegate_type = function

--- a/csharp/templates/HTTP_actions.mustache
+++ b/csharp/templates/HTTP_actions.mustache
@@ -29,5 +29,19 @@ namespace XenAPI
         }
 
 {{/http_actions}}
+
+        public static void get_pool_patch_download(HTTP.DataCopiedDelegate dataCopiedDelegate, HTTP.FuncBool cancellingDelegate, int timeout_ms,
+            string hostname, IWebProxy proxy, string path, string task_id, string session_id, string uuid)
+        {
+            Get(dataCopiedDelegate, cancellingDelegate, timeout_ms, hostname, "/pool_patch_download", proxy, path,
+                "task_id", task_id, "session_id", session_id, "uuid", uuid);
+        }
+
+        public static void put_oem_patch_stream(HTTP.UpdateProgressDelegate progressDelegate, HTTP.FuncBool cancellingDelegate, int timeout_ms,
+            string hostname, IWebProxy proxy, string path, string task_id, string session_id)
+        {
+            Put(progressDelegate, cancellingDelegate, timeout_ms, hostname, "/oem_patch_stream", proxy, path,
+                "task_id", task_id, "session_id", session_id);
+        }
     }
 }

--- a/csharp/templates/HTTP_actions.mustache
+++ b/csharp/templates/HTTP_actions.mustache
@@ -1,0 +1,33 @@
+{{{licence}}}
+
+using System;
+using System.Text;
+using System.Net;
+
+namespace XenAPI
+{
+    public partial class HTTP_actions
+    {
+        private static void Get(HTTP.DataCopiedDelegate dataCopiedDelegate, HTTP.FuncBool cancellingDelegate, int timeout_ms,
+            string hostname, string remotePath, IWebProxy proxy, string localPath, params object[] args)
+        {
+            HTTP.Get(dataCopiedDelegate, cancellingDelegate, HTTP.BuildUri(hostname, remotePath, args), proxy, localPath, timeout_ms);
+        }
+
+        private static void Put(HTTP.UpdateProgressDelegate progressDelegate, HTTP.FuncBool cancellingDelegate, int timeout_ms,
+            string hostname, string remotePath, IWebProxy proxy, string localPath, params object[] args)
+        {
+            HTTP.Put(progressDelegate, cancellingDelegate, HTTP.BuildUri(hostname, remotePath, args), proxy, localPath, timeout_ms);
+        }
+
+{{#http_actions}}
+        public static void {{name}}(HTTP.{{delegate_type}} {{delegate_name}}, HTTP.FuncBool cancellingDelegate, int timeout_ms,
+            string hostname, IWebProxy proxy, string path, {{{sdkargs_decl}}})
+        {
+            {{http_method}}({{delegate_name}}, cancellingDelegate, timeout_ms, hostname, "{{uri}}", proxy, path,
+                {{{sdkargs}}});
+        }
+
+{{/http_actions}}
+    }
+}

--- a/powershell/autogen/src/Receive-XenPoolPatch.cs
+++ b/powershell/autogen/src/Receive-XenPoolPatch.cs
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Citrix Systems, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1) Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *   2) Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials
+ *      provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Text;
+
+using XenAPI;
+
+namespace Citrix.XenServer.Commands
+{
+    [Cmdlet(VerbsCommunications.Receive, "XenPoolPatch", SupportsShouldProcess = false)]
+    [OutputType(typeof(void))]
+    public class ReceiveXenPoolPatchCommand : XenServerHttpCmdlet
+    {
+        #region Cmdlet Parameters
+
+        [Parameter]
+        public HTTP.DataCopiedDelegate DataCopiedDelegate { get; set; }
+
+        [Parameter(ValueFromPipelineByPropertyName = true)]
+        public string Uuid { get; set; }
+
+        #endregion
+
+        #region Cmdlet Methods
+
+        protected override void ProcessRecord()
+        {
+            GetSession();
+
+            RunApiCall(() => XenAPI.HTTP_actions.get_pool_patch_download(DataCopiedDelegate,
+                CancellingDelegate, TimeoutMs, XenHost, Proxy, Path, TaskRef,
+                session.opaque_ref, Uuid));
+        }
+
+        #endregion
+    }
+}

--- a/powershell/autogen/src/Send-XenOemPatchStream.cs
+++ b/powershell/autogen/src/Send-XenOemPatchStream.cs
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Citrix Systems, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1) Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *   2) Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials
+ *      provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Text;
+
+using XenAPI;
+
+namespace Citrix.XenServer.Commands
+{
+    [Cmdlet(VerbsCommunications.Send, "XenOemPatchStream", SupportsShouldProcess = true)]
+    [OutputType(typeof(void))]
+    public class SendXenOemPatchStreamCommand : XenServerHttpCmdlet
+    {
+        #region Cmdlet Parameters
+
+        [Parameter]
+        public HTTP.UpdateProgressDelegate ProgressDelegate { get; set; }
+
+        #endregion
+
+        #region Cmdlet Methods
+
+        protected override void ProcessRecord()
+        {
+            GetSession();
+
+            if (!ShouldProcess("/oem_patch_stream"))
+                return;
+
+            RunApiCall(() => XenAPI.HTTP_actions.put_oem_patch_stream(ProgressDelegate,
+                CancellingDelegate, TimeoutMs, XenHost, Proxy, Path, TaskRef,
+                session.opaque_ref));
+        }
+
+        #endregion
+    }
+}

--- a/powershell/gen_powershell_binding.ml
+++ b/powershell/gen_powershell_binding.ml
@@ -191,15 +191,15 @@ and gen_arg_param = function
                             (pascal_case_ x)
   | Int64_query_arg x -> sprintf "
         [Parameter]
-        public long %s { get; set; }\n" (pascal_case_ x)
+        public long? %s { get; set; }\n" (pascal_case_ x)
   | Bool_query_arg x ->
     let y = if x = "host" then "is_host" else x in
     sprintf "
         [Parameter]
-        public bool %s { get; set; }\n" (pascal_case_ y)
+        public bool? %s { get; set; }\n" (pascal_case_ y)
   | Varargs_query_arg -> sprintf "
         ///<summary>
-        /// Alternate names & values
+        /// Alternate names and values
         ///</summary>
         [Parameter]
         public string[] Args { get; set; }\n"

--- a/powershell/templates/XenServerPowerShell.csproj.mustache
+++ b/powershell/templates/XenServerPowerShell.csproj.mustache
@@ -63,6 +63,8 @@
     <Compile Include="ConvertTo-XenRef.cs" />
     <Compile Include="Disconnect-XenServer.cs" />
     <Compile Include="Get-XenSession.cs" />
+    <Compile Include="Receive-XenPoolPatch.cs" />
+    <Compile Include="Send-XenOemPatchStream.cs" />
     <Compile Include="Wait-XenTask.cs" />
     <Compile Include="XenServerCmdlet.cs" />
     <Compile Include="XenServerHttpCmdlet.cs" />


### PR DESCRIPTION
CA-345342: Made the query parameters of the http actions optional using as default value the type default.

Note that some of them are not optional, however, the current definition does not allow for distinguishing them from the mandatory ones, and as a consequence it is easier to mark them all as optional than provide method overloads manually.
Also, exposed manually in the SDK http actions removed from the API.
Use a mustache template to generate the HTTP actions.