### PR TITLE
CA-365905 (XSI-1215): Create a temporary file in the target download …

### DIFF
--- a/csharp/autogen/src/HTTP.cs
+++ b/csharp/autogen/src/HTTP.cs
@@ -75,9 +75,7 @@ namespace XenAPI
             public override void GetObjectData(SerializationInfo info, StreamingContext context)
             {
                 if (info == null)
-                {
-                    throw new ArgumentNullException("info");
-                }
+                    throw new ArgumentNullException(nameof(info));
 
                 info.AddValue("redirect", redirect);
                 info.AddValue("uri", uri, typeof(Uri));
@@ -773,11 +771,29 @@ namespace XenAPI
         public static void Get(DataCopiedDelegate dataCopiedDelegate, FuncBool cancellingDelegate,
             Uri uri, IWebProxy proxy, string path, int timeoutMs)
         {
-            string tmpFile = Path.GetTempFileName();
+            if (string.IsNullOrWhiteSpace(path))
+                throw new ArgumentException(nameof(path));
+
+            var tmpFile = Path.GetTempFileName();
+
+            if (Path.GetPathRoot(path) != Path.GetPathRoot(tmpFile))
+            {
+                //CA-365905: if the target path is under a root different from
+                //the temp file, use instead a temp file under the target root,
+                //otherwise there may not be enough space for the download
+
+                var dir = Path.GetDirectoryName(path);
+                if (dir == null) //path is root directory
+                    throw new ArgumentException(nameof(path));
+
+                tmpFile = Path.Combine(dir, Path.GetRandomFileName());
+                File.Delete(tmpFile);
+            }
+
             try
             {
                 using (Stream fileStream = new FileStream(tmpFile, FileMode.Create, FileAccess.Write, FileShare.None),
-                    downloadStream = HttpGetStream(uri, proxy, timeoutMs))
+                       downloadStream = HttpGetStream(uri, proxy, timeoutMs))
                 {
                     CopyStream(downloadStream, fileStream, dataCopiedDelegate, cancellingDelegate);
                     fileStream.Flush();


### PR DESCRIPTION
…folder instead of the user's temp folder if the latter is in a different drive from the target folder.